### PR TITLE
KBV-342 Record audit events in Session Handler

### DIFF
--- a/session/src/main/java/uk/gov/di/ipv/cri/address/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/address/api/handler/SessionHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
@@ -47,7 +48,9 @@ public class SessionHandler
                 new SessionRequestService(),
                 new EventProbe(),
                 new AuditService(
-                        AmazonSQSClientBuilder.defaultClient(), new ConfigurationService()));
+                        AmazonSQSClientBuilder.defaultClient(),
+                        new ConfigurationService(),
+                        new ObjectMapper()));
     }
 
     public SessionHandler(
@@ -70,6 +73,7 @@ public class SessionHandler
         try {
             SessionRequest sessionRequest =
                     sesssionRequestService.validateSessionRequest(input.getBody());
+            auditService.sendAuditEvent(AuditEventTypes.IPV_ADDRESS_CRI_START);
 
             eventProbe.addDimensions(Map.of("issuer", sessionRequest.getClientId()));
 
@@ -77,8 +81,6 @@ public class SessionHandler
 
             eventProbe.counterMetric(EVENT_SESSION_CREATED).auditEvent(sessionRequest);
 
-            auditService.sendAuditEvent(
-                    AuditEventTypes.SESSION_CREATED, sessionId, sessionRequest.getClientId());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_CREATED,
                     Map.of(

--- a/session/src/test/java/uk/gov/di/ipv/cri/address/api/handler/SessionHandlerTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/address/api/handler/SessionHandlerTest.java
@@ -81,7 +81,7 @@ class SessionHandlerTest {
 
         verify(eventProbe).addDimensions(Map.of("issuer", "ipv-core"));
         verify(eventProbe).counterMetric("session_created");
-        verify(auditService).sendAuditEvent(AuditEventTypes.SESSION_CREATED, sessionId, "ipv-core");
+        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_ADDRESS_CRI_START);
     }
 
     @Test
@@ -106,7 +106,7 @@ class SessionHandlerTest {
         verify(eventProbe).counterMetric("session_created", 0d);
         verify(eventProbe).log(Level.ERROR, sessionValidationException);
 
-        verify(auditService, never()).sendAuditEvent(any(), any(), any());
+        verify(auditService, never()).sendAuditEvent(any());
         verify(sessionService, never()).createAndSaveAddressSession(sessionRequest);
     }
 
@@ -129,7 +129,7 @@ class SessionHandlerTest {
 
         verify(eventProbe).counterMetric("session_created", 0d);
 
-        verify(auditService, never()).sendAuditEvent(any(), any(), any());
+        verify(auditService, never()).sendAuditEvent(any());
         verify(sessionService, never()).createAndSaveAddressSession(sessionRequest);
     }
 


### PR DESCRIPTION
There are some conflicts on SessionHandler on a  [PR that existed before](https://github.com/alphagov/di-ipv-cri-address-api/pull/109) we moved some lambdas  to this common lambdas repo.

I'm moving the files causing that conflict to this common lambdas repo.