### PR TITLE
[KBV-517] Amend Audit Service and Calls

### DIFF
--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.UUID;
 
@@ -53,7 +54,8 @@ public class SessionHandler
                 new AuditService(
                         SqsClient.builder().build(),
                         new ConfigurationService(),
-                        new ObjectMapper()));
+                        new ObjectMapper(),
+                        Clock.systemUTC()));
     }
 
     public SessionHandler(

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -12,7 +12,7 @@ import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
 import uk.gov.di.ipv.cri.common.api.service.SessionRequestService;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.cri.common.library.domain.AuditEventTypes;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.domain.SessionRequest;
 import uk.gov.di.ipv.cri.common.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.common.library.exception.ClientConfigurationException;
@@ -79,7 +79,7 @@ public class SessionHandler
             SessionRequest sessionRequest =
                     sesssionRequestService.validateSessionRequest(input.getBody());
 
-            auditService.sendAuditEvent(getAuditEventType(sessionRequest.getAudience()));
+            auditService.sendAuditEvent(AuditEventType.START);
 
             eventProbe.addDimensions(Map.of("issuer", sessionRequest.getClientId()));
 
@@ -112,18 +112,5 @@ public class SessionHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.SERVER_CONFIG_ERROR);
         }
-    }
-
-    // TODO revisit implementation (temporary implementation below)
-    private AuditEventTypes getAuditEventType(String audience) {
-        String normalisedAudience = audience.toLowerCase();
-        if (normalisedAudience.contains("kbv")) {
-            return AuditEventTypes.IPV_KBV_CRI_START;
-        } else if (normalisedAudience.contains("address")) {
-            return AuditEventTypes.IPV_ADDRESS_CRI_START;
-        } else if (normalisedAudience.contains("fraud")) {
-            return AuditEventTypes.IPV_FRAUD_CRI_START;
-        }
-        throw new IllegalArgumentException("Unexpected Audience encountered: " + audience);
     }
 }

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.common.api.service.SessionRequestService;
-import uk.gov.di.ipv.cri.common.library.domain.AuditEventTypes;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.domain.SessionRequest;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
 import uk.gov.di.ipv.cri.common.library.error.ErrorResponse;
@@ -39,6 +39,7 @@ import static uk.gov.di.ipv.cri.common.api.handler.SessionHandler.REDIRECT_URI;
 import static uk.gov.di.ipv.cri.common.api.handler.SessionHandler.SESSION_ID;
 import static uk.gov.di.ipv.cri.common.api.handler.SessionHandler.STATE;
 
+@SuppressWarnings("rawtypes")
 @ExtendWith(MockitoExtension.class)
 class SessionHandlerTest {
 
@@ -73,7 +74,6 @@ class SessionHandlerTest {
                 .thenReturn(URI.create("https://www.example.com/callback"));
         when(sessionRequest.hasSharedClaims()).thenReturn(Boolean.TRUE);
         when(sessionRequest.getSharedClaims()).thenReturn(sharedClaims);
-        when(sessionRequest.getAudience()).thenReturn("kbv");
         when(apiGatewayProxyRequestEvent.getBody()).thenReturn("some json");
         when(sessionRequestService.validateSessionRequest("some json")).thenReturn(sessionRequest);
         when(sessionService.saveSession(sessionRequest)).thenReturn(sessionId);
@@ -91,7 +91,7 @@ class SessionHandlerTest {
         verify(personIdentityService).savePersonIdentity(sessionId, sharedClaims);
         verify(eventProbe).addDimensions(Map.of("issuer", "ipv-core"));
         verify(eventProbe).counterMetric("session_created");
-        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_KBV_CRI_START);
+        verify(auditService).sendAuditEvent(AuditEventType.START);
     }
 
     @Test
@@ -116,7 +116,7 @@ class SessionHandlerTest {
         verify(eventProbe).counterMetric("session_created", 0d);
         verify(eventProbe).log(Level.ERROR, sessionValidationException);
 
-        verify(auditService, never()).sendAuditEvent(any());
+        verify(auditService, never()).sendAuditEvent(any(AuditEventType.class));
         verify(sessionService, never()).saveSession(sessionRequest);
     }
 
@@ -139,7 +139,7 @@ class SessionHandlerTest {
 
         verify(eventProbe).counterMetric("session_created", 0d);
 
-        verify(auditService, never()).sendAuditEvent(any());
+        verify(auditService, never()).sendAuditEvent(any(AuditEventType.class));
         verify(sessionService, never()).saveSession(sessionRequest);
     }
 

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.common.api.handler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,6 @@ import static uk.gov.di.ipv.cri.common.api.handler.SessionHandler.REDIRECT_URI;
 import static uk.gov.di.ipv.cri.common.api.handler.SessionHandler.SESSION_ID;
 import static uk.gov.di.ipv.cri.common.api.handler.SessionHandler.STATE;
 
-@SuppressWarnings("rawtypes")
 @ExtendWith(MockitoExtension.class)
 class SessionHandlerTest {
 
@@ -108,7 +108,8 @@ class SessionHandlerTest {
         APIGatewayProxyResponseEvent responseEvent =
                 sessionHandler.handleRequest(apiGatewayProxyRequestEvent, null);
         assertEquals(HttpStatusCode.BAD_REQUEST, responseEvent.getStatusCode());
-        Map responseBody = new ObjectMapper().readValue(responseEvent.getBody(), Map.class);
+        Map<String, Object> responseBody =
+                new ObjectMapper().readValue(responseEvent.getBody(), new TypeReference<>() {});
         assertEquals(ErrorResponse.SESSION_VALIDATION_ERROR.getCode(), responseBody.get("code"));
         assertEquals(
                 ErrorResponse.SESSION_VALIDATION_ERROR.getMessage(), responseBody.get("message"));
@@ -133,7 +134,8 @@ class SessionHandlerTest {
         APIGatewayProxyResponseEvent responseEvent =
                 sessionHandler.handleRequest(apiGatewayProxyRequestEvent, null);
         assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, responseEvent.getStatusCode());
-        Map responseBody = new ObjectMapper().readValue(responseEvent.getBody(), Map.class);
+        Map<String, Object> responseBody =
+                new ObjectMapper().readValue(responseEvent.getBody(), new TypeReference<>() {});
         assertEquals(ErrorResponse.SERVER_CONFIG_ERROR.getCode(), responseBody.get("code"));
         assertEquals(ErrorResponse.SERVER_CONFIG_ERROR.getMessage(), responseBody.get("message"));
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Utilise the new simplified events

### Why did it change

The SQS Event System was very tailored to each service, despite being in the common libraries - this meant keeping a list of enums for all CRIs within the common library - this would not be maintainable in the long run.
Considering these all consisted of the CRI name as a prefix, we decided to move this prefix to an environment variable and prepend it to the event

### Issue tracking
- [KBV-517](https://govukverify.atlassian.net/browse/KBV-517)
