### PR TITLE
LIME-45 Retrieve persistent_session_id and govuk_signin_journey_id fr…

### DIFF
--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -99,6 +99,8 @@ public class SessionHandler
             SessionItem auditSessionItem = new SessionItem();
             auditSessionItem.setSessionId(sessionId);
             auditSessionItem.setSubject(sessionRequest.getSubject());
+            auditSessionItem.setPersistentSessionId(sessionRequest.getPersistentSessionId());
+            auditSessionItem.setClientSessionId(sessionRequest.getClientSessionId());
             auditService.sendAuditEvent(
                     AuditEventType.START,
                     new AuditEventContext(input.getHeaders(), auditSessionItem));

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
@@ -24,6 +24,8 @@ public class SessionRequestService {
     private static final String SHARED_CLAIMS_NAME = "shared_claims";
     private static final String REDIRECT_URI = "redirect_uri";
     private static final String CLIENT_ID = "client_id";
+    private static final String PERSISTENT_SESSION_ID = "persistent_session_id";
+    private static final String CLIENT_SESSION_ID = "govuk_signin_journey_id";
 
     private final ObjectMapper objectMapper;
     private final JWTVerifier jwtVerifier;
@@ -89,6 +91,15 @@ public class SessionRequestService {
             sessionRequest.setSignedJWT(requestJWT);
             sessionRequest.setState(jwtClaims.getStringClaim("state"));
             sessionRequest.setSubject(jwtClaims.getSubject());
+
+            if (jwtClaims.getClaims().containsKey(PERSISTENT_SESSION_ID)) {
+                sessionRequest.setPersistentSessionId(
+                        jwtClaims.getStringClaim(PERSISTENT_SESSION_ID));
+            }
+
+            if (jwtClaims.getClaims().containsKey(CLIENT_SESSION_ID)) {
+                sessionRequest.setClientSessionId(jwtClaims.getStringClaim(CLIENT_SESSION_ID));
+            }
 
             if (jwtClaims.getClaims().containsKey(SHARED_CLAIMS_NAME)) {
                 SharedClaims sharedClaims =

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
@@ -71,6 +71,8 @@ class SessionHandlerTest {
         SharedClaims sharedClaims = new SharedClaims();
         Map<String, String> requestHeaders = Map.of("header-name", "headerValue");
         String subject = "subject";
+        String persistentSessionId = "persistent_session_id_value";
+        String clientSessionId = "govuk_signin_journey_id_value";
         ArgumentCaptor<AuditEventContext> auditEventContextArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEventContext.class);
         when(eventProbe.counterMetric(anyString())).thenReturn(eventProbe);
@@ -81,6 +83,8 @@ class SessionHandlerTest {
         when(sessionRequest.hasSharedClaims()).thenReturn(Boolean.TRUE);
         when(sessionRequest.getSharedClaims()).thenReturn(sharedClaims);
         when(sessionRequest.getSubject()).thenReturn(subject);
+        when(sessionRequest.getPersistentSessionId()).thenReturn(persistentSessionId);
+        when(sessionRequest.getClientSessionId()).thenReturn(clientSessionId);
         when(apiGatewayProxyRequestEvent.getBody()).thenReturn("some json");
         when(apiGatewayProxyRequestEvent.getHeaders()).thenReturn(requestHeaders);
         when(sessionRequestService.validateSessionRequest("some json")).thenReturn(sessionRequest);
@@ -105,6 +109,9 @@ class SessionHandlerTest {
         AuditEventContext auditEventContext = auditEventContextArgumentCaptor.getValue();
         assertEquals(subject, auditEventContext.getSessionItem().getSubject());
         assertEquals(sessionId, auditEventContext.getSessionItem().getSessionId());
+        assertEquals(
+                persistentSessionId, auditEventContext.getSessionItem().getPersistentSessionId());
+        assertEquals(clientSessionId, auditEventContext.getSessionItem().getClientSessionId());
         assertEquals(requestHeaders, auditEventContext.getRequestHeaders());
     }
 

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestServiceTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestServiceTest.java
@@ -184,6 +184,12 @@ class SessionRequestServiceTest {
         assertThat(
                 sessionRequest.getResponseType(),
                 equalTo(jwtClaims.getStringClaim("response_type")));
+        assertThat(
+                sessionRequest.getPersistentSessionId(),
+                equalTo(jwtClaims.getStringClaim("persistent_session_id")));
+        assertThat(
+                sessionRequest.getClientSessionId(),
+                equalTo(jwtClaims.getStringClaim("govuk_signin_journey_id")));
     }
 
     private String marshallToJSON(Object sessionRequest) throws IOException {

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
@@ -41,6 +41,8 @@ class SignedJWTBuilder {
     private String audience = "test-audience";
     private boolean includeSubject = true;
     private boolean includeSharedClaims = false;
+    private String persistentSessionId = "persistentSessionIdTest";
+    private String clientSessionId = "clientSessionIdTest";
 
     SignedJWTBuilder setNow(Instant now) {
         this.now = now;
@@ -97,6 +99,16 @@ class SignedJWTBuilder {
         return this;
     }
 
+    SignedJWTBuilder setPersistentSessionId(String persistentSessionId) {
+        this.persistentSessionId = persistentSessionId;
+        return this;
+    }
+
+    SignedJWTBuilder setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+        return this;
+    }
+
     Certificate getCertificate() {
         return certificate;
     }
@@ -123,7 +135,9 @@ class SignedJWTBuilder {
                                     ResponseType.CODE.stream().findFirst().get().getValue())
                             .claim("client_id", clientId)
                             .claim("redirect_uri", redirectUri)
-                            .claim("state", "state");
+                            .claim("state", "state")
+                            .claim("persistent_session_id", persistentSessionId)
+                            .claim("govuk_signin_journey_id", clientSessionId);
 
             if (includeSubject) {
                 jwtClaimSetBuilder.subject(ipv_session_id);


### PR DESCRIPTION
## Proposed changes

### What changed

Retrieve persistent_session_id and govuk_signin_journey_id from JWT.

### Why did it change

The relaying allows PersistentSessionId and ClientSessionId to appear in the user section of AuditEvents.

PersistentSessionId= "persistent_session_id"
ClientSessionId = "govuk_signin_journey_id" 
ClientSessionId follows [IPVAuthorisationService](https://github.com/alphagov/di-authentication-api/pull/2183/files) for variable naming.

Linked with [Common-Lib 42](https://github.com/alphagov/di-ipv-cri-lib/pull/42)

### Issue tracking

- [LIME-45](https://govukverify.atlassian.net/browse/LIME-45)
- [ADR-0039](https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0039-govuk-signin-journey-id.md)
- [RFC-0023](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0023-crossteam-audit-and-analysis-eventmessage-payload.md)