### PR TITLE
Oj 933 add common lib jar dependency

### DIFF
--- a/accesstoken/build.gradle
+++ b/accesstoken/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-	implementation project(":common-lib"),
+	implementation configurations.common_lib,
 			configurations.aws,
 			configurations.lambda,
 			configurations.nimbus,

--- a/accesstoken/build.gradle
+++ b/accesstoken/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-	implementation configurations.common_lib,
+	implementation configurations.cri_common_lib,
 			configurations.aws,
 			configurations.lambda,
 			configurations.nimbus,

--- a/authorization/build.gradle
+++ b/authorization/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-	implementation project(":common-lib"),
+	implementation configurations.common_lib,
 			configurations.aws,
 			configurations.lambda,
 			configurations.nimbus,

--- a/authorization/build.gradle
+++ b/authorization/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-	implementation configurations.common_lib,
+	implementation configurations.cri_common_lib,
 			configurations.aws,
 			configurations.lambda,
 			configurations.nimbus,

--- a/authorization/src/test/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandlerTest.java
+++ b/authorization/src/test/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandlerTest.java
@@ -97,7 +97,7 @@ class AuthorizationHandlerTest {
         assertEquals(1020, responseBody.get("code"));
         assertEquals("Server Configuration Error", responseBody.get("message"));
 
-        verify(eventProbe).log(any(), any());
+        verify(eventProbe).log(any(Level.class), any(Exception.class));
     }
 
     @Test
@@ -140,6 +140,6 @@ class AuthorizationHandlerTest {
         assertEquals("Session Validation Exception", responseBody.get("message"));
 
         verify(mockSessionService).getSession(sessionId.toString());
-        verify(eventProbe).log(any(), any());
+        verify(eventProbe).log(any(Level.class), any(Exception.class));
     }
 }

--- a/session/build.gradle
+++ b/session/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-	implementation project(":common-lib"),
+	implementation configurations.common_lib,
 			configurations.aws,
 			configurations.lambda,
 			configurations.nimbus,

--- a/session/build.gradle
+++ b/session/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-	implementation configurations.common_lib,
+	implementation configurations.cri_common_lib,
 			configurations.aws,
 			configurations.lambda,
 			configurations.nimbus,


### PR DESCRIPTION
### What changed
- Removed dependency on common-lib project / git submodule
- Added reference to new cri-common-lib jar

### Why did it change
- To enable the common-lib git submodule to be retired

### Issue tracking
- [OJ-933](https://govukverify.atlassian.net/browse/OJ-933)

### Other considerations

- The Address / KBV / Fraud CRI will need to be updated in order to use this latest version of the common-lambdas git submodule