### PR TITLE
OJ-934 update matrix common CRI deployment

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -14,9 +14,11 @@ jobs:
           - target: KBV_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: KBV_DEV_SIGNING_PROFILE_NAME
           - target: KBV_POC
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: KBV_POC_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to dev
     runs-on: ubuntu-latest
@@ -28,6 +30,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v1
@@ -41,12 +49,23 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
+      - name: Generate code signing config
+        id: signing
+        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
+        with:
+          template: ./infrastructure/lambda/template.yaml
+          profile: ${{ {{ secrets[matrix.SIGNING_PROFILE_NAME] }}
+
+      - name: Gradle build
+        run: ./gradlew build
+
       - name: SAM build
         run: sam build -t infrastructure/lambda/template.yaml
 
       - name: SAM package
         run: |
           sam package -t infrastructure/lambda/template.yaml  \
+            ${{ steps.signing.outputs.signing_config }} \
             --s3-bucket ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }} \
             --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
 
@@ -68,6 +87,7 @@ jobs:
           - target: KBV_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    KBV_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: KBV_BUILD_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to build
     runs-on: ubuntu-latest
@@ -79,6 +99,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v1
@@ -92,12 +118,23 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
+      - name: Generate code signing config
+        id: signing
+        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
+        with:
+          template: ./infrastructure/lambda/template.yaml
+          profile: ${{ {{ secrets[matrix.SIGNING_PROFILE_NAME] }}
+
+      - name: Gradle build
+        run: ./gradlew build
+
       - name: SAM build
         run: sam build -t infrastructure/lambda/template.yaml
 
       - name: SAM package
         run: |
           sam package -t infrastructure/lambda/template.yaml  \
+            ${{ steps.signing.outputs.signing_config }} \
             --s3-bucket ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }} \
             --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
 
@@ -108,3 +145,4 @@ jobs:
         env:
           ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
         run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"
+        

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Common CRI secrets for dev environments:
 |------------------------------------------------|------------------------|
 | KBV_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
 | KBV_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN         | Assumed role IAM ARN   |
+| KBV_DEV_SIGNING_PROFILE_NAME                   | Signing profile name   |
 | KBV_POC_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
 | KBV_POC_COMMON_CRI_GH_ACTIONS_ROLE_ARN         | Assumed role IAM ARN   |
+| KBV_POC_SIGNING_PROFILE_NAME                   | Signing profile name   |
 
 Common CRI secrets for Build environments:
 
@@ -29,4 +31,5 @@ Common CRI secrets for Build environments:
 |--------------------------------------------------|------------------------|
 | KBV_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
 | KBV_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN         | Assumed role IAM ARN   |
+| KBV_BUILD_SIGNING_PROFILE_NAME                   | Signing profile name   |
 


### PR DESCRIPTION
## Proposed changes

### What changed

Updated matrix workflow to include java build and signing steps

### Why did it change

Missing from previous iteration which failed the deployment

### Issue tracking

- [OJ-934](https://govukverify.atlassian.net/browse/OJ-934)

## Checklists

### Environment variables or secrets

- [X] Documented in the [README](./blob/main/README.md)
- [X] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

None