### PR TITLE
OJ-924: Save client ip address provided to /session API call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.1.1"
+		cri_common_lib           : "1.1.3"
 	]
 }
 

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -41,7 +41,7 @@ public class SessionHandler
     protected static final String STATE = "state";
     protected static final String REDIRECT_URI = "redirect_uri";
     private static final String EVENT_SESSION_CREATED = "session_created";
-    private static final String HEADER_IP_ADDRESS = "X-Forwarded-For";
+    private static final String HEADER_IP_ADDRESS = "x-forwarded-for";
     private final SessionService sessionService;
     private final SessionRequestService sesssionRequestService;
     private final PersonIdentityService personIdentityService;

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -41,6 +41,7 @@ public class SessionHandler
     protected static final String STATE = "state";
     protected static final String REDIRECT_URI = "redirect_uri";
     private static final String EVENT_SESSION_CREATED = "session_created";
+    private static final String HEADER_IP_ADDRESS = "X-Forwarded-For";
     private final SessionService sessionService;
     private final SessionRequestService sesssionRequestService;
     private final PersonIdentityService personIdentityService;
@@ -84,7 +85,8 @@ public class SessionHandler
         try {
             SessionRequest sessionRequest =
                     sesssionRequestService.validateSessionRequest(input.getBody());
-
+            var sessionHeaderIpAddress = input.getHeaders().get(HEADER_IP_ADDRESS);
+            sessionRequest.setClientIpAddress(sessionHeaderIpAddress);
             eventProbe.addDimensions(Map.of("issuer", sessionRequest.getClientId()));
 
             UUID sessionId = sessionService.saveSession(sessionRequest);

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
@@ -69,8 +69,11 @@ class SessionHandlerTest {
 
         UUID sessionId = UUID.randomUUID();
         SharedClaims sharedClaims = new SharedClaims();
-        Map<String, String> requestHeaders = Map.of("header-name", "headerValue");
-        requestHeaders.put("X-Forwarded-For", "192.0.2.0");
+        Map<String, String> requestHeaders =
+                Map.of(
+                        "header-name", "headerValue",
+                        "x-forwarded-for", "192.0.2.0");
+
         String subject = "subject";
         String persistentSessionId = "persistent_session_id_value";
         String clientSessionId = "govuk_signin_journey_id_value";
@@ -101,6 +104,7 @@ class SessionHandlerTest {
         assertEquals("https://www.example.com/callback", responseBody.get(REDIRECT_URI));
 
         verify(sessionService).saveSession(sessionRequest);
+        verify(sessionRequest).setClientIpAddress("192.0.2.0");
         verify(personIdentityService).savePersonIdentity(sessionId, sharedClaims);
         verify(eventProbe).addDimensions(Map.of("issuer", "ipv-core"));
         verify(eventProbe).counterMetric("session_created");

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
@@ -70,6 +70,7 @@ class SessionHandlerTest {
         UUID sessionId = UUID.randomUUID();
         SharedClaims sharedClaims = new SharedClaims();
         Map<String, String> requestHeaders = Map.of("header-name", "headerValue");
+        requestHeaders.put("X-Forwarded-For", "192.0.2.0");
         String subject = "subject";
         String persistentSessionId = "persistent_session_id_value";
         String clientSessionId = "govuk_signin_journey_id_value";


### PR DESCRIPTION
## Proposed changes
Get "x-forwarded-for"  header value from /session api to get the ip address and send it to Persistence layer.

### What changed

Reading the header value "x-forwarded-for" for session API and storing.

### Why did it change

To reuse Client IP address of client to send to TXMA.


### Issue tracking

- [OJ-924](https://govukverify.atlassian.net/browse/OJ-924)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks