### PR TITLE
OJ-925 : Sending IP Address to TxMA event

### DIFF
--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -100,6 +100,7 @@ public class SessionHandler
 
             SessionItem auditSessionItem = new SessionItem();
             auditSessionItem.setSessionId(sessionId);
+            auditSessionItem.setClientIpAddress(sessionHeaderIpAddress);
             auditSessionItem.setSubject(sessionRequest.getSubject());
             auditSessionItem.setPersistentSessionId(sessionRequest.getPersistentSessionId());
             auditSessionItem.setClientSessionId(sessionRequest.getClientSessionId());

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandlerTest.java
@@ -116,6 +116,7 @@ class SessionHandlerTest {
         assertEquals(
                 persistentSessionId, auditEventContext.getSessionItem().getPersistentSessionId());
         assertEquals(clientSessionId, auditEventContext.getSessionItem().getClientSessionId());
+        assertEquals("192.0.2.0", auditEventContext.getSessionItem().getClientIpAddress());
         assertEquals(requestHeaders, auditEventContext.getRequestHeaders());
     }
 


### PR DESCRIPTION
## Proposed changes

Send Ip address to TxMA event, for a  new /session.

### What changed

Send Ip address to TxMA event.

### Why did it change

To reuse Client IP address of client to send to TXMA.

### Issue tracking

- [OJ-925](https://govukverify.atlassian.net/browse/OJ-925)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks