### PR TITLE
LIME-147 - Adding accessDenied error handling to authorization lambda

### DIFF
--- a/authorization/src/main/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandler.java
+++ b/authorization/src/main/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandler.java
@@ -15,6 +15,7 @@ import software.amazon.lambda.powertools.metrics.Metrics;
 import uk.gov.di.ipv.cri.common.api.service.AuthorizationValidatorService;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.error.ErrorResponse;
+import uk.gov.di.ipv.cri.common.library.error.OauthErrorResponse;
 import uk.gov.di.ipv.cri.common.library.exception.SessionValidationException;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
@@ -92,6 +93,10 @@ public class AuthorizationHandler
             eventProbe.log(ERROR, e).counterMetric(EVENT_AUTHORIZATION_SENT, 0d);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.BAD_REQUEST, ErrorResponse.SESSION_VALIDATION_ERROR);
+        } catch (Exception e) {
+            eventProbe.log(ERROR, e).counterMetric(EVENT_AUTHORIZATION_SENT, 0d);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatusCode.INTERNAL_SERVER_ERROR, OauthErrorResponse.ACCESS_DENIED_ERROR);
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.1.3"
+		cri_common_lib           : "1.1.6"
 	]
 }
 


### PR DESCRIPTION

### What changed

Added error handling for access denied oauth error (for routing back to IpvCore) in authorization lambda

### Why did it change

So that correct access denied error can be returned to Ipv core in the event of a user escaping mid journey (e.c in Driving licence Cri)