### PR TITLE
LIME-125: Added logging helper to session lambda and conditional response so we can decouple the back and frontend of passport when we switch to common lambdas

### DIFF
--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/domain/JarResponse.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/domain/JarResponse.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.cri.common.api.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.Map;
+
+@ExcludeFromGeneratedCoverageReport
+public class JarResponse {
+    @JsonProperty("shared_claims")
+    private Map<String, Object> sharedClaims;
+
+    @JsonProperty("passportSessionId")
+    private String passportSessionId;
+
+    public JarResponse(Map<String, Object> sharedClaims, String passportSessionId) {
+        this.sharedClaims = sharedClaims;
+        this.passportSessionId = passportSessionId;
+    }
+
+    public Map<String, Object> getSharedClaims() {
+        return sharedClaims;
+    }
+
+    public String getPassportSessionId() {
+        return passportSessionId;
+    }
+}

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.regions.Region;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
+import uk.gov.di.ipv.cri.common.api.domain.JarResponse;
 import uk.gov.di.ipv.cri.common.api.service.SessionRequestService;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
@@ -30,11 +32,13 @@ import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
+import java.text.ParseException;
 import java.time.Clock;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.logging.log4j.Level.ERROR;
+import static software.amazon.awssdk.http.HttpStatusCode.BAD_REQUEST;
 
 public class SessionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -44,15 +48,18 @@ public class SessionHandler
     protected static final String REDIRECT_URI = "redirect_uri";
     private static final String EVENT_SESSION_CREATED = "session_created";
     private static final String HEADER_IP_ADDRESS = "x-forwarded-for";
+    private static final String SHARED_CLAIMS = "shared_claims";
+
     private final SessionService sessionService;
     private final SessionRequestService sesssionRequestService;
     private final PersonIdentityService personIdentityService;
     private final EventProbe eventProbe;
     private final AuditService auditService;
+    private final ConfigurationService configurationService;
 
     @ExcludeFromGeneratedCoverageReport
     public SessionHandler() {
-        ConfigurationService configurationService = new ConfigurationService();
+        this.configurationService = new ConfigurationService();
         this.sessionService = new SessionService();
         this.sesssionRequestService = new SessionRequestService();
         this.personIdentityService = new PersonIdentityService();
@@ -74,12 +81,14 @@ public class SessionHandler
             SessionRequestService sessionRequestService,
             PersonIdentityService personIdentityService,
             EventProbe eventProbe,
-            AuditService auditService) {
+            AuditService auditService,
+            ConfigurationService configurationService) {
         this.sessionService = sessionService;
         this.sesssionRequestService = sessionRequestService;
         this.personIdentityService = personIdentityService;
         this.eventProbe = eventProbe;
         this.auditService = auditService;
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -87,13 +96,18 @@ public class SessionHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachComponentIdToLogs();
 
         try {
             SessionRequest sessionRequest =
                     sesssionRequestService.validateSessionRequest(input.getBody());
+
             var sessionHeaderIpAddress = input.getHeaders().get(HEADER_IP_ADDRESS);
             sessionRequest.setClientIpAddress(sessionHeaderIpAddress);
             eventProbe.addDimensions(Map.of("issuer", sessionRequest.getClientId()));
+
+            String clientId = sessionRequest.getClientId();
+            LogHelper.attachClientIdToLogs(clientId);
 
             UUID sessionId = sessionService.saveSession(sessionRequest);
 
@@ -109,9 +123,19 @@ public class SessionHandler
             auditSessionItem.setSubject(sessionRequest.getSubject());
             auditSessionItem.setPersistentSessionId(sessionRequest.getPersistentSessionId());
             auditSessionItem.setClientSessionId(sessionRequest.getClientSessionId());
+
+            // Must ensure issuer param is set for passport
             auditService.sendAuditEvent(
                     AuditEventType.START,
                     new AuditEventContext(input.getHeaders(), auditSessionItem));
+
+            if (configurationService.getVerifiableCredentialIssuer().contains("review-p")) {
+                JarResponse jarResponse =
+                        generateJarResponse(
+                                sessionRequest.getSignedJWT().getJWTClaimsSet(), sessionId);
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatusCode.CREATED, jarResponse);
+            }
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.CREATED,
@@ -125,13 +149,22 @@ public class SessionHandler
             eventProbe.log(ERROR, e).counterMetric(EVENT_SESSION_CREATED, 0d);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatusCode.BAD_REQUEST, ErrorResponse.SESSION_VALIDATION_ERROR);
+                    BAD_REQUEST, ErrorResponse.SESSION_VALIDATION_ERROR);
         } catch (ClientConfigurationException | SqsException e) {
 
             eventProbe.log(ERROR, e).counterMetric(EVENT_SESSION_CREATED, 0d);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.SERVER_CONFIG_ERROR);
+        } catch (ParseException e) {
+            eventProbe.log(ERROR, e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE_SHARED_ATTRIBUTES_JWT);
         }
+    }
+
+    private JarResponse generateJarResponse(JWTClaimsSet claimsSet, UUID sessionId)
+            throws ParseException {
+        return new JarResponse(claimsSet.getJSONObjectClaim(SHARED_CLAIMS), sessionId.toString());
     }
 }

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
@@ -27,7 +27,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 
-class SignedJWTBuilder {
+public class SignedJWTBuilder {
 
     private String issuer = "ipv-core";
     private Instant now = Instant.now();
@@ -113,7 +113,7 @@ class SignedJWTBuilder {
         return certificate;
     }
 
-    SignedJWT build() {
+    public SignedJWT build() {
         try {
 
             PrivateKey privateKey = getPrivateKeyFromResources(privateKeyFile);


### PR DESCRIPTION
## Proposed changes

### What changed

Added logging helper to session lambda and conditional response 

### Why did it change

So we can decouple the back and frontend of passport when we switch to common lambdas

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-125](https://govukverify.atlassian.net/browse/LIME-125)

