### PR TITLE
OJ-997 - Added new integration test for session endpoint

### DIFF
--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/runners/RunCucumberTest.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/runners/RunCucumberTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         plugin = {"json:target/cucumber.json", "html:target/default-html-reports"},
-        features = "src/test/resources",
+        features = "src/test/resources/features",
         glue = "gov/uk/di/ipv/cri/common/api/stepDefinitions",
         dryRun = false)
 public class RunCucumberTest {}

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -1,18 +1,15 @@
 package gov.uk.di.ipv.cri.common.api.stepDefinitions;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.uk.di.ipv.cri.common.api.util.IpvCoreStubUtil;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.apache.http.client.utils.URIBuilder;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
 
@@ -21,40 +18,37 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class APISteps {
 
+    private final String DEV_SESSION_URI = "/dev/session";
     private String sessionRequestBody;
     private HttpResponse<String> response;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private Map<String, String> bodyMap;
-    private String authorizationCode;
+    private Map<String, String> responseBodyMap;
 
     @Given("authorization JAR for test user {int}")
     public void setAuthorizationJARForTestUser(int rowNumber)
             throws URISyntaxException, IOException, InterruptedException {
-        String ipvCoreStubURL = IpvCoreStubUtil.getIPVCoreStubURL();
-        String userIdentityJson = IpvCoreStubUtil.getClaimsForUser(ipvCoreStubURL, rowNumber);
-        sessionRequestBody = IpvCoreStubUtil.createRequest(ipvCoreStubURL, userIdentityJson);
+        String userIdentityJson = IpvCoreStubUtil.getClaimsForUser(rowNumber);
+        sessionRequestBody = IpvCoreStubUtil.sendCreateSessionRequest(userIdentityJson);
     }
 
     @When("user sends a request to session API")
     public void user_sends_a_request_to_session_api()
             throws URISyntaxException, IOException, InterruptedException {
-        sendSessionRequest(HttpRequest.BodyPublishers.ofString(sessionRequestBody));
-        bodyMap = objectMapper.readValue(response.body(), new TypeReference<>() {});
+        response = IpvCoreStubUtil.sendSessionRequest(DEV_SESSION_URI, sessionRequestBody);
+        responseBodyMap = objectMapper.readValue(response.body(), new TypeReference<>() {});
     }
 
     @Then("user gets a session id")
     public void user_gets_a_session_id() {
         assertEquals(201, response.statusCode());
-        assertNotNull(bodyMap.get("session_id"));
+        assertNotNull(responseBodyMap.get("session_id"));
     }
 
     @When("user sends an empty request to session end point")
     public void user_sends_an_empty_request_to_session_end_point()
             throws URISyntaxException, IOException, InterruptedException {
-        sendSessionRequest(HttpRequest.BodyPublishers.noBody());
-        String body = response.body();
-
-        bodyMap = objectMapper.readValue(body, new TypeReference<>() {});
+        response = IpvCoreStubUtil.sendSessionRequest(DEV_SESSION_URI, "");
+        responseBodyMap = objectMapper.readValue(response.body(), new TypeReference<>() {});
     }
 
     @Then("expect a status code of {int} in the response")
@@ -68,55 +62,5 @@ public class APISteps {
                 objectMapper.readValue(sessionRequestBody, new TypeReference<>() {});
         map.remove(key);
         sessionRequestBody = objectMapper.writeValueAsString(map);
-    }
-
-    @When("user sends a GET request to authorization end point")
-    public void user_sends_a_get_request_to_authorization_end_point()
-            throws IOException, InterruptedException, URISyntaxException {
-        var url =
-                new URIBuilder(IpvCoreStubUtil.getPrivateAPIEndpoint())
-                        .setPath("/dev/authorization")
-                        .addParameter(
-                                "redirect_uri",
-                                "https://di-ipv-core-stub.london.cloudapps.digital/callback")
-                        .addParameter("client_id", "ipv-core-stub")
-                        .addParameter("response_type", "code")
-                        .addParameter("scope", "openid")
-                        .addParameter("state", "state-ipv")
-                        .build();
-
-        var sessionId = bodyMap.get("session_id");
-        System.out.println("✨✨✨✨ session id is " + sessionId);
-        var request =
-                HttpRequest.newBuilder()
-                        .uri(url)
-                        .setHeader("Accept", "application/json")
-                        .setHeader("session-id", sessionId)
-                        .GET()
-                        .build();
-
-        response = IpvCoreStubUtil.sendHttpRequest(request);
-    }
-
-    @And("a valid authorization code is returned in the response")
-    public void aValidAuthorizationCodeIsReturnedInTheResponse() throws IOException {
-        JsonNode jsonNode = objectMapper.readTree(response.body());
-        authorizationCode = jsonNode.get("authorizationCode").get("value").textValue();
-        assertNotNull(authorizationCode);
-    }
-
-    private void sendSessionRequest(HttpRequest.BodyPublisher sessionRequestBody)
-            throws URISyntaxException, IOException, InterruptedException {
-        var request =
-                HttpRequest.newBuilder()
-                        .uri(
-                                new URIBuilder(IpvCoreStubUtil.getPrivateAPIEndpoint())
-                                        .setPath("/dev/session")
-                                        .build())
-                        .setHeader("Accept", "application/json")
-                        .setHeader("Content-Type", "application/json")
-                        .POST(sessionRequestBody)
-                        .build();
-        response = IpvCoreStubUtil.sendHttpRequest(request);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -45,7 +45,7 @@ public class IpvCoreStubUtil {
         return sendHttpRequest(request).body();
     }
 
-    public static HttpResponse<String> sendHttpRequest(HttpRequest request)
+    private static HttpResponse<String> sendHttpRequest(HttpRequest request)
             throws IOException, InterruptedException {
 
         String basicAuthUser =
@@ -72,7 +72,7 @@ public class IpvCoreStubUtil {
         return client.send(request, HttpResponse.BodyHandlers.ofString());
     }
 
-    public static String getIPVCoreStubURL() {
+    private static String getIPVCoreStubURL() {
         return Optional.ofNullable(System.getenv("IPV_CORE_STUB_URL"))
                 .orElseThrow(
                         () ->
@@ -100,14 +100,11 @@ public class IpvCoreStubUtil {
         return sendHttpRequest(request).body();
     }
 
-    public static HttpResponse<String> sendSessionRequest(String sessionRequestBody)
+    public static HttpResponse<String> sendSessionRequest(String apiPath, String sessionRequestBody)
             throws URISyntaxException, IOException, InterruptedException {
         var request =
                 HttpRequest.newBuilder()
-                        .uri(
-                                new URIBuilder(getPrivateApiEndpoint())
-                                        .setPath("/dev/session")
-                                        .build())
+                        .uri(new URIBuilder(getPrivateApiEndpoint()).setPath(apiPath).build())
                         .setHeader("Accept", "application/json")
                         .setHeader("Content-Type", "application/json")
                         .POST(HttpRequest.BodyPublishers.ofString(sessionRequestBody))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
We have created a happy case scenario to test session endpoint

### Why did it change

This test will act as a QA gateway.

### Issue tracking
 
https://govukverify.atlassian.net/browse/OJ-997
## Checklists

### Environment variables or secrets

STACK_NAME=di-ipv-cri-xxx 
API_GATEWAY_ID_PRIVATE=xxx 
IPV_CORE_STUB_BASIC_AUTH_USER=xxx 
IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxx 
IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" 

### To run the test

`STACK_NAME=di-ipv-cri-xxx  API_GATEWAY_ID_PRIVATE=xxx  IPV_CORE_STUB_BASIC_AUTH_USER=xxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital"  gradle integration-tests:cucumber`