### PR TITLE
OJ-1001: Add Authorization integration test

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -308,6 +308,8 @@ Resources:
         - AWSXrayWriteOnlyAccess
         - DynamoDBReadPolicy:
             TableName: !Ref SessionTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionTable
         - Statement:
             - Effect: Allow
               Action:

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -13,18 +13,22 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class APISteps {
 
-    private final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
-    private final String DEV_SESSION_URI = ENVIRONMENT + "/session";
-    private final String DEV_AUTHORIZATION_URI = ENVIRONMENT + "/authorization";
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
+    private static final String DEV_SESSION_URI = ENVIRONMENT + "/session";
+    private static final String DEV_AUTHORIZATION_URI = ENVIRONMENT + "/authorization";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String DEFAULT_REDIRECT_URI =
+            "https://di-ipv-core-stub.london.cloudapps.digital/callback";
+    private static final String DEFAULT_CLIENT_ID = "ipv-core-stub";
     private String sessionRequestBody;
-    private String sessionId;
+    private String currentSessionId;
     private HttpResponse<String> response;
     private Map<String, String> responseBodyMap;
 
@@ -46,7 +50,7 @@ public class APISteps {
     public void user_gets_a_session_id() {
         assertEquals(201, response.statusCode());
         assertNotNull(responseBodyMap.get("session_id"));
-        sessionId = responseBodyMap.get("session_id");
+        currentSessionId = responseBodyMap.get("session_id");
     }
 
     @When("user sends an empty request to session end point")
@@ -69,22 +73,56 @@ public class APISteps {
         sessionRequestBody = objectMapper.writeValueAsString(map);
     }
 
-    @And("user sends an address")
-    public void userSendsAnAddress() throws IOException, URISyntaxException, InterruptedException {
-        IpvCoreStubUtil.sendAddress(sessionId);
-    }
-
-    @When("user sends a request to authorization end point")
-    public void user_sends_a_request_to_authorization_end_point()
+    @When("user sends a valid request to authorization end point")
+    public void user_sends_a_valid_request_to_authorization_end_point()
             throws IOException, InterruptedException, URISyntaxException {
-        response = IpvCoreStubUtil.sendAuthorizationRequest(DEV_AUTHORIZATION_URI, sessionId);
+        response =
+                IpvCoreStubUtil.sendAuthorizationRequest(
+                        DEV_AUTHORIZATION_URI,
+                        currentSessionId,
+                        DEFAULT_REDIRECT_URI,
+                        DEFAULT_CLIENT_ID);
     }
 
     @And("a valid authorization code is returned in the response")
     public void aValidAuthorizationCodeIsReturnedInTheResponse() throws IOException {
         JsonNode jsonNode = objectMapper.readTree(response.body());
-        assertNotNull(jsonNode.get("authorizationCode").get("value").textValue());
-        assertNotNull(jsonNode.get("redirectionURI").textValue());
-        assertNotNull(jsonNode.get("state").get("value").textValue());
+        assertEquals(
+                UUID.fromString(jsonNode.get("authorizationCode").get("value").textValue())
+                        .toString(),
+                jsonNode.get("authorizationCode").get("value").textValue());
+        assertEquals(DEFAULT_REDIRECT_URI, jsonNode.get("redirectionURI").textValue());
+        assertEquals("state-ipv", jsonNode.get("state").get("value").textValue());
+    }
+
+    @When("user sends a request to authorization end point with invalid client id")
+    public void user_sends_a_request_to_authorization_end_point_with_invalid_client_id()
+            throws URISyntaxException, IOException, InterruptedException {
+        response =
+                IpvCoreStubUtil.sendAuthorizationRequest(
+                        DEV_AUTHORIZATION_URI,
+                        currentSessionId,
+                        DEFAULT_REDIRECT_URI,
+                        "INVALID-CLIENT-ID");
+    }
+
+    @When("user sends a request to authorization end point with invalid redirect uri")
+    public void userSendsARequestToAuthorizationEndPointWithInvalidRedirectUri()
+            throws URISyntaxException, IOException, InterruptedException {
+        response =
+                IpvCoreStubUtil.sendAuthorizationRequest(
+                        DEV_AUTHORIZATION_URI,
+                        currentSessionId,
+                        "https://wrong-incorrect-url/callback",
+                        DEFAULT_CLIENT_ID);
+    }
+
+    @And("a {string} error with code {int} is sent in the response body")
+    public void aErrorWithCodeIsSentInTheResponseBody(String errorMessage, int errorCode)
+            throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(response.body());
+        assertEquals(errorCode, jsonNode.get("code").asInt());
+        assertEquals("Session Validation Exception", errorMessage);
+        assertEquals(errorCode + ": " + errorMessage, jsonNode.get("errorSummary").asText());
     }
 }

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -16,8 +16,6 @@ public class IpvCoreStubUtil {
 
     private static final String ADDRESS_CRI_DEV = "address-cri-dev";
     private static final String API_GATEWAY_ID_PRIVATE = "API_GATEWAY_ID_PRIVATE";
-    private static final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
-    private static final String DEV_AUTHORIZATION_URI = ENVIRONMENT + "/authorization";
 
     private static String getPrivateApiEndpoint() {
         String apiEndpoint = System.getenv(API_GATEWAY_ID_PRIVATE);
@@ -114,39 +112,14 @@ public class IpvCoreStubUtil {
         return sendHttpRequest(request);
     }
 
-    public static HttpResponse<String> createAuthorizationRequest(String sessionId)
-            throws URISyntaxException, IOException, InterruptedException {
-        var url =
-                new URIBuilder(getPrivateApiEndpoint())
-                        .setPath(DEV_AUTHORIZATION_URI)
-                        .addParameter(
-                                "redirect_uri",
-                                "https://di-ipv-core-stub.london.cloudapps.digital/callback")
-                        .addParameter("client_id", "ipv-core-stub")
-                        .addParameter("response_type", "code")
-                        .addParameter("scope", "openid")
-                        .addParameter("state", "state-ipv")
-                        .build();
-        var request =
-                HttpRequest.newBuilder()
-                        .uri(url)
-                        .setHeader("Accept", "application/json")
-                        .setHeader("session-id", sessionId)
-                        .GET()
-                        .build();
-
-        return sendHttpRequest(request);
-    }
-
-    public static HttpResponse<String> sendAuthorizationRequest(String apiPath, String sessionId)
+    public static HttpResponse<String> sendAuthorizationRequest(
+            String apiPath, String sessionId, String redirectUri, String clientId)
             throws URISyntaxException, IOException, InterruptedException {
         var url =
                 new URIBuilder(getPrivateApiEndpoint())
                         .setPath(apiPath)
-                        .addParameter(
-                                "redirect_uri",
-                                "https://di-ipv-core-stub.london.cloudapps.digital/callback")
-                        .addParameter("client_id", "ipv-core-stub")
+                        .addParameter("redirect_uri", redirectUri)
+                        .addParameter("client_id", clientId)
                         .addParameter("response_type", "code")
                         .addParameter("scope", "openid")
                         .addParameter("state", "state-ipv")
@@ -160,40 +133,5 @@ public class IpvCoreStubUtil {
                         .build();
 
         return sendHttpRequest(request);
-    }
-
-    public static void sendAddress(String sessionId)
-            throws IOException, InterruptedException, URISyntaxException {
-
-        String requestBody =
-                "["
-                        + "{"
-                        + "    \"uprn\": \"123456789\","
-                        + "    \"organisationName\": \"PRIME MINISTER & FIRST LORD OF THE TREASURY\","
-                        + "    \"buildingNumber\": \"10\","
-                        + "    \"thoroughfareName\": \"BERRYMEAD GARDENS\","
-                        + "    \"postTown\": \"LONDON\","
-                        + "    \"postcode\": \"W3 8AA\","
-                        + "    \"countryCode\": \"GBR\","
-                        + "    \"validFrom\": \"2021-01-01\""
-                        + "  }"
-                        + "]";
-
-        var request =
-                HttpRequest.newBuilder()
-                        .uri(
-                                new URIBuilder(getPrivateApiEndpoint())
-                                        .setPath("/dev/address")
-                                        .build())
-                        .setHeader("session_id", sessionId)
-                        .PUT(HttpRequest.BodyPublishers.ofString(requestBody))
-                        .build();
-        var response = sendHttpRequest(request);
-        if (response.statusCode() != 204)
-            throw new IllegalStateException(
-                    "Address PUT endpoint returned status code: "
-                            + response.statusCode()
-                            + " with body: "
-                            + response.body());
     }
 }

--- a/integration-tests/src/test/resources/features/AuthorizationAPI.feature
+++ b/integration-tests/src/test/resources/features/AuthorizationAPI.feature
@@ -4,23 +4,18 @@ Feature: Authorization API
     Given authorization JAR for test user 681
     When user sends a request to session API
     Then user gets a session id
-    #This is a pre-requisite step before calling the authorization end point
-    And user sends an address
 
   Scenario: a valid authorization code is returned
-   When user sends a request to authorization end point
+   When user sends a valid request to authorization end point
     Then expect a status code of 200 in the response
     And a valid authorization code is returned in the response
 
-#  Scenario: no authorization code is returned when client id does not match
-#    When user sends a request to authorization end point
-#    And the request body has no client_id
-#    Then expect a status code of 400 in the response
+  Scenario: no authorization code is returned when client id does not match
+    When user sends a request to authorization end point with invalid client id
+    Then expect a status code of 400 in the response
+    And a "Session Validation Exception" error with code 1019 is sent in the response body
 
-
-
-
-
-
-
-
+  Scenario: no authorization code is returned when redirect uri does not match
+    When user sends a request to authorization end point with invalid redirect uri
+    Then expect a status code of 400 in the response
+    And a "Session Validation Exception" error with code 1019 is sent in the response body

--- a/integration-tests/src/test/resources/features/AuthorizationAPI.feature
+++ b/integration-tests/src/test/resources/features/AuthorizationAPI.feature
@@ -1,0 +1,26 @@
+Feature: Authorization API
+
+  Background: a session id is returned
+    Given authorization JAR for test user 681
+    When user sends a request to session API
+    Then user gets a session id
+    #This is a pre-requisite step before calling the authorization end point
+    And user sends an address
+
+  Scenario: a valid authorization code is returned
+   When user sends a request to authorization end point
+    Then expect a status code of 200 in the response
+    And a valid authorization code is returned in the response
+
+#  Scenario: no authorization code is returned when client id does not match
+#    When user sends a request to authorization end point
+#    And the request body has no client_id
+#    Then expect a status code of 400 in the response
+
+
+
+
+
+
+
+

--- a/integration-tests/src/test/resources/features/SessionAPI.feature
+++ b/integration-tests/src/test/resources/features/SessionAPI.feature
@@ -20,4 +20,3 @@ Feature: Session API
     And the request body has no request
     When user sends a request to session API
     Then expect a status code of 400 in the response
-


### PR DESCRIPTION
### Requirement
Add cucumber integration test to the `di-ipv-cri-common-lambdas` for `authorization` end point

### Important considerations:
- It was found during development that it is imperative to call the `AddressHandler` first before we invoke the Authorization handler as that in turn creates the `authorization code`. This code is `mandatory` when sending back the Authorization response. Without this code, the integration test for Authorization Handler will never pass.
- It has also been discussed if `authorization code` should be responsibility of the `cris`. This opened a few implications that all the handlers will need to be amended/changed and tested.
- A simpler fix was to call the code to create the `authorization code` within the Authorization Handler. This way there was no change on any of the `cris`. The `authorization code` is created only when there is no code already created for that session.
- It was also discussed that the Authorization Handler is a `GET` request. However, since now we are going to write to the session table, should it be a `POST` request? Again this change would mean a change in the code beginning from the frontend to the backend.

### What changed
- Added new `feature` file for Authorization end point
- New steps added to the `APISteps` file

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1001](https://govukverify.atlassian.net/browse/OJ-1001)

### Other considerations
To run the tests:

`STACK_NAME=di-ipv-cri-address-xxxx API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" gradle integration-tests:cucumber`

