### PR TITLE
OJ-999 - Add driving-permit CRI configuration

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -121,6 +121,11 @@ Mappings:
       build: "https://review-k.build.account.gov.uk"
       staging: "https://review-k.staging.account.gov.uk"
       integration: "https://review-k.integration.account.gov.uk"
+    di-ipv-cri-driving-permit-api:
+      dev: "https://review-d.dev.account.gov.uk"
+      build: "https://review-d.build.account.gov.uk"
+      staging: "https://review-d.staging.account.gov.uk"
+      integration: "https://review-d.integration.account.gov.uk"
 
   IPVCoreStubPreProdAudienceMapping:
     di-ipv-cri-address-api:
@@ -129,6 +134,8 @@ Mappings:
       production: "https://review-f.account.gov.uk"
     di-ipv-cri-kbv-api:
       production: "https://review-k.account.gov.uk"
+    di-ipv-cri-driving-permit-api:
+      production: "https://review-d.account.gov.uk"
 
   IPVCore1AudienceMapping:
     di-ipv-cri-address-api:
@@ -143,6 +150,10 @@ Mappings:
       staging: "https://review-k.staging.account.gov.uk"
       integration: "https://review-k.integration.account.gov.uk"
       production: "https://review-k.account.gov.uk"
+    di-ipv-cri-driving-permit-api:
+      staging: "https://review-d.staging.account.gov.uk"
+      integration: "https://review-d.integration.account.gov.uk"
+      production: "https://review-d.account.gov.uk"
 
   IPVCoreStubIssuerMapping:
     Environment:
@@ -202,6 +213,10 @@ Mappings:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv"
       integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=kbv"
       production: "https://identity.account.gov.uk/credential-issuer/callback?id=kbv"
+    di-ipv-cri-driving-permit-api:
+      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=driving-permit"
+      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=driving-permit"
+      production: "https://identity.account.gov.uk/credential-issuer/callback?id=driving-permit"
 
   VerifiableCredentialIssuerMapping:
     di-ipv-cri-address-api:
@@ -222,6 +237,12 @@ Mappings:
       staging: "https://review-k.staging.account.gov.uk"
       integration: "https://review-k.integration.account.gov.uk"
       production: "https://review-k.account.gov.uk"
+    di-ipv-cri-driving-permit-api:
+      dev: "https://review-d.dev.account.gov.uk"
+      build: "https://review-d.build.account.gov.uk"
+      staging: "https://review-d.staging.account.gov.uk"
+      integration: "https://review-d.integration.account.gov.uk"
+      production: "https://review-d.account.gov.uk"
 
 Resources:
   SessionFunction:


### PR DESCRIPTION
### What changed
- Added driving-permit CRI specific configuration to the existing mappings in `template.yaml`

The values were obtained from: 
https://github.com/alphagov/di-ipv-cri-dl-api/blob/main/infrastructure/lambda/template.yaml

### Why did it change
- To enable the driving-permit CRI to transition to the common CRI framework

### Issue tracking
- [OJ-999](https://govukverify.atlassian.net/browse/OJ-999)

