### PR TITLE
OJ-1014: Add Access Token integration test

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -67,7 +67,7 @@ jobs:
           IPV_CORE_STUB_URL: https://di-ipv-core-stub.london.cloudapps.digital
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}
-          APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
+          PUBLIC_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
         run: |
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
           API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PreMergeDevOnlyApiId").OutputValue')

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -67,11 +67,11 @@ jobs:
           IPV_CORE_STUB_URL: https://di-ipv-core-stub.london.cloudapps.digital
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}
+          APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
         run: |
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
           API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PreMergeDevOnlyApiId").OutputValue')
           export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
-
           gradle integration-tests:cucumber
 
       - name: Delete integration test stack

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -12,10 +12,8 @@ import io.cucumber.java.en.When;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -25,12 +23,11 @@ public class APISteps {
     private static final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
     private static final String DEV_SESSION_URI = ENVIRONMENT + "/session";
     private static final String DEV_AUTHORIZATION_URI = ENVIRONMENT + "/authorization";
-    private static final String DEV_ACCESS_TOKEN_URI = ENVIRONMENT + "/token";
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static String authorizationCode;
     private static final String DEFAULT_REDIRECT_URI =
             "https://di-ipv-core-stub.london.cloudapps.digital/callback";
     private static final String DEFAULT_CLIENT_ID = "ipv-core-stub";
+    private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;
     private HttpResponse<String> response;
@@ -91,8 +88,9 @@ public class APISteps {
     @And("a valid authorization code is returned in the response")
     public void aValidAuthorizationCodeIsReturnedInTheResponse() throws IOException {
         JsonNode jsonNode = objectMapper.readTree(response.body());
-        authorizationCode = jsonNode.get("authorizationCode").get("value").textValue();
-        assertEquals(UUID.fromString(authorizationCode).toString(), authorizationCode);
+        currentAuthorizationCode = jsonNode.get("authorizationCode").get("value").textValue();
+        assertEquals(
+                UUID.fromString(currentAuthorizationCode).toString(), currentAuthorizationCode);
         assertEquals(DEFAULT_REDIRECT_URI, jsonNode.get("redirectionURI").textValue());
         assertEquals("state-ipv", jsonNode.get("state").get("value").textValue());
     }
@@ -119,21 +117,10 @@ public class APISteps {
                         DEFAULT_CLIENT_ID);
     }
 
-    @And("a {string} error with code {int} is sent in the response body")
-    public void aErrorWithCodeIsSentInTheResponseBody(String errorMessage, int errorCode)
-            throws IOException {
-        JsonNode jsonNode = objectMapper.readTree(response.body());
-        assertEquals(errorCode, jsonNode.get("code").asInt());
-        assertEquals("Session Validation Exception", errorMessage);
-        assertEquals(errorCode + ": " + errorMessage, jsonNode.get("errorSummary").asText());
-    }
-
     @When("user sends a request to access token end point")
     public void userSendsARequestToAccessTokenEndPoint()
             throws URISyntaxException, IOException, InterruptedException {
-        response =
-                IpvCoreStubUtil.sendAccessTokenRequest(
-                        DEV_ACCESS_TOKEN_URI, getPrivateKeyJWT(authorizationCode));
+        response = IpvCoreStubUtil.sendAccessTokenRequest(currentAuthorizationCode);
     }
 
     @And("a valid access token is returned in the response")
@@ -142,11 +129,6 @@ public class APISteps {
         assertNotNull(jsonNode.get("access_token").asText());
         assertEquals("Bearer", jsonNode.get("token_type").asText());
         assertEquals(3600, jsonNode.get("expires_in").asInt());
-    }
-
-    private String getPrivateKeyJWT(String authorizationCode)
-            throws URISyntaxException, IOException, InterruptedException {
-        return IpvCoreStubUtil.getPrivateKeyJWT(authorizationCode);
     }
 
     @And("a {string} error with code {int} is sent in the response")
@@ -158,50 +140,9 @@ public class APISteps {
         assertEquals(errorCode + ": " + errorMessage, jsonNode.get("errorSummary").asText());
     }
 
-    @When("user sends a request to access token end point with incorrect grant type")
-    public void userSendsARequestToAccessTokenEndPointWithIncorrectGrantType()
-            throws URISyntaxException, IOException, InterruptedException {
-        String privateKeyJWT = getPrivateKeyJWT(authorizationCode);
-        Map<String, String> map = new HashMap<String, String>();
-
-        for (String keyValue : privateKeyJWT.split("&")) {
-            String[] pairs = keyValue.split("=");
-            map.put(pairs[0], pairs.length == 1 ? "" : pairs[1]);
-        }
-        map.put("grant_type", "wrong_authorization_code");
-
-        privateKeyJWT =
-                map.keySet().stream()
-                        .map(key -> key + "=" + map.get(key))
-                        .collect(Collectors.joining(", ", "[", "]"));
-        response = IpvCoreStubUtil.sendAccessTokenRequest(DEV_ACCESS_TOKEN_URI, privateKeyJWT);
-    }
-
-    @When("user sends a request to access token end point with missing {string}")
-    public void userSendsARequestToAccessTokenEndPointWithMissing(String removeKey)
-            throws URISyntaxException, IOException, InterruptedException {
-        String privateKeyJWT = getPrivateKeyJWT(authorizationCode);
-
-        Map<String, String> simpleMap = new HashMap<>();
-        if (removeKey != null) {
-            for (String keyValue : privateKeyJWT.split("&")) {
-                String[] pairs = keyValue.split("=");
-                simpleMap.put(pairs[0], pairs.length == 1 ? "" : pairs[1]);
-            }
-            simpleMap.remove(removeKey);
-            privateKeyJWT =
-                    simpleMap.keySet().stream()
-                            .map(key -> key + "=" + simpleMap.get(key))
-                            .collect(Collectors.joining(", ", "[", "]"));
-        }
-        response = IpvCoreStubUtil.sendAccessTokenRequest(DEV_ACCESS_TOKEN_URI, privateKeyJWT);
-    }
-
     @When("user sends a request to access token end point with incorrect authorization code")
     public void userSendsARequestToAccessTokenEndPointWithIncorrectAuthorizationCode()
             throws URISyntaxException, IOException, InterruptedException {
-        response =
-                IpvCoreStubUtil.sendAccessTokenRequest(
-                        DEV_ACCESS_TOKEN_URI, getPrivateKeyJWT("wrong_authorization_code"));
+        response = IpvCoreStubUtil.sendAccessTokenRequest("wrong_authorization_code");
     }
 }

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -12,8 +12,10 @@ import io.cucumber.java.en.When;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,7 +25,9 @@ public class APISteps {
     private static final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
     private static final String DEV_SESSION_URI = ENVIRONMENT + "/session";
     private static final String DEV_AUTHORIZATION_URI = ENVIRONMENT + "/authorization";
+    private static final String DEV_ACCESS_TOKEN_URI = ENVIRONMENT + "/token";
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static String authorizationCode;
     private static final String DEFAULT_REDIRECT_URI =
             "https://di-ipv-core-stub.london.cloudapps.digital/callback";
     private static final String DEFAULT_CLIENT_ID = "ipv-core-stub";
@@ -87,10 +91,8 @@ public class APISteps {
     @And("a valid authorization code is returned in the response")
     public void aValidAuthorizationCodeIsReturnedInTheResponse() throws IOException {
         JsonNode jsonNode = objectMapper.readTree(response.body());
-        assertEquals(
-                UUID.fromString(jsonNode.get("authorizationCode").get("value").textValue())
-                        .toString(),
-                jsonNode.get("authorizationCode").get("value").textValue());
+        authorizationCode = jsonNode.get("authorizationCode").get("value").textValue();
+        assertEquals(UUID.fromString(authorizationCode).toString(), authorizationCode);
         assertEquals(DEFAULT_REDIRECT_URI, jsonNode.get("redirectionURI").textValue());
         assertEquals("state-ipv", jsonNode.get("state").get("value").textValue());
     }
@@ -124,5 +126,82 @@ public class APISteps {
         assertEquals(errorCode, jsonNode.get("code").asInt());
         assertEquals("Session Validation Exception", errorMessage);
         assertEquals(errorCode + ": " + errorMessage, jsonNode.get("errorSummary").asText());
+    }
+
+    @When("user sends a request to access token end point")
+    public void userSendsARequestToAccessTokenEndPoint()
+            throws URISyntaxException, IOException, InterruptedException {
+        response =
+                IpvCoreStubUtil.sendAccessTokenRequest(
+                        DEV_ACCESS_TOKEN_URI, getPrivateKeyJWT(authorizationCode));
+    }
+
+    @And("a valid access token is returned in the response")
+    public void aValidAccessTokenIsReturnedInTheResponse() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(response.body());
+        assertNotNull(jsonNode.get("access_token").asText());
+        assertEquals("Bearer", jsonNode.get("token_type").asText());
+        assertEquals(3600, jsonNode.get("expires_in").asInt());
+    }
+
+    private String getPrivateKeyJWT(String authorizationCode)
+            throws URISyntaxException, IOException, InterruptedException {
+        return IpvCoreStubUtil.getPrivateKeyJWT(authorizationCode);
+    }
+
+    @And("a {string} error with code {int} is sent in the response")
+    public void aErrorWithCodeIsSentInTheResponse(String errorMessage, int errorCode)
+            throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(response.body());
+        assertEquals(errorCode, jsonNode.get("code").asInt());
+        assertEquals(errorMessage, jsonNode.get("message").asText());
+        assertEquals(errorCode + ": " + errorMessage, jsonNode.get("errorSummary").asText());
+    }
+
+    @When("user sends a request to access token end point with incorrect grant type")
+    public void userSendsARequestToAccessTokenEndPointWithIncorrectGrantType()
+            throws URISyntaxException, IOException, InterruptedException {
+        String privateKeyJWT = getPrivateKeyJWT(authorizationCode);
+        Map<String, String> map = new HashMap<String, String>();
+
+        for (String keyValue : privateKeyJWT.split("&")) {
+            String[] pairs = keyValue.split("=");
+            map.put(pairs[0], pairs.length == 1 ? "" : pairs[1]);
+        }
+        map.put("grant_type", "wrong_authorization_code");
+
+        privateKeyJWT =
+                map.keySet().stream()
+                        .map(key -> key + "=" + map.get(key))
+                        .collect(Collectors.joining(", ", "[", "]"));
+        response = IpvCoreStubUtil.sendAccessTokenRequest(DEV_ACCESS_TOKEN_URI, privateKeyJWT);
+    }
+
+    @When("user sends a request to access token end point with missing {string}")
+    public void userSendsARequestToAccessTokenEndPointWithMissing(String removeKey)
+            throws URISyntaxException, IOException, InterruptedException {
+        String privateKeyJWT = getPrivateKeyJWT(authorizationCode);
+
+        Map<String, String> simpleMap = new HashMap<>();
+        if (removeKey != null) {
+            for (String keyValue : privateKeyJWT.split("&")) {
+                String[] pairs = keyValue.split("=");
+                simpleMap.put(pairs[0], pairs.length == 1 ? "" : pairs[1]);
+            }
+            simpleMap.remove(removeKey);
+            privateKeyJWT =
+                    simpleMap.keySet().stream()
+                            .map(key -> key + "=" + simpleMap.get(key))
+                            .collect(Collectors.joining(", ", "[", "]"));
+        }
+        response = IpvCoreStubUtil.sendAccessTokenRequest(DEV_ACCESS_TOKEN_URI, privateKeyJWT);
+    }
+
+    @When("user sends a request to access token end point with incorrect authorization code")
+    public void userSendsARequestToAccessTokenEndPointWithIncorrectAuthorizationCode()
+            throws URISyntaxException, IOException, InterruptedException {
+        response =
+                IpvCoreStubUtil.sendAccessTokenRequest(
+                        DEV_ACCESS_TOKEN_URI, getPrivateKeyJWT("wrong_authorization_code"));
     }
 }

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -16,7 +16,6 @@ public class IpvCoreStubUtil {
 
     private static final String ADDRESS_CRI_DEV = "address-cri-dev";
     private static final String API_GATEWAY_ID_PRIVATE = "API_GATEWAY_ID_PRIVATE";
-    private static final String API_GATEWAY_ID_PUBLIC = "API_GATEWAY_ID_PUBLIC";
 
     private static String getPrivateApiEndpoint() {
         String apiEndpoint = System.getenv(API_GATEWAY_ID_PRIVATE);
@@ -27,18 +26,6 @@ public class IpvCoreStubUtil {
                                         String.format(
                                                 "Environment variable %s is not assigned",
                                                 API_GATEWAY_ID_PRIVATE)));
-        return "https://" + apiEndpoint + ".execute-api.eu-west-2.amazonaws.com";
-    }
-
-    private static String getPublicApiEndpoint() {
-        String apiEndpoint = System.getenv(API_GATEWAY_ID_PUBLIC);
-        Optional.ofNullable(apiEndpoint)
-                .orElseThrow(
-                        () ->
-                                new IllegalArgumentException(
-                                        String.format(
-                                                "Environment variable %s is not assigned",
-                                                API_GATEWAY_ID_PUBLIC)));
         return "https://" + apiEndpoint + ".execute-api.eu-west-2.amazonaws.com";
     }
 
@@ -155,7 +142,7 @@ public class IpvCoreStubUtil {
         var request =
                 HttpRequest.newBuilder()
                         .uri(
-                                new URIBuilder(getPublicApiEndpoint())
+                                new URIBuilder(getPrivateApiEndpoint())
                                         .setPath(devAccessTokenUri)
                                         .build())
                         .header("Content-Type", "application/x-www-form-urlencoded")
@@ -186,6 +173,12 @@ public class IpvCoreStubUtil {
     }
 
     private static String getPublicAPIKey() {
-        return Optional.ofNullable(System.getenv("APIGW_API_KEY")).orElseThrow();
+        return Optional.ofNullable(System.getenv("APIGW_API_KEY"))
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        String.format(
+                                                "Environment variable %s is not assigned",
+                                                "APIGW_API_KEY")));
     }
 }

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -135,16 +135,14 @@ public class IpvCoreStubUtil {
         return sendHttpRequest(request);
     }
 
-    public static HttpResponse<String> sendAccessTokenRequest(
-            String devAccessTokenUri, String privateKeyJWT)
+    public static HttpResponse<String> sendAccessTokenRequest(String authorizationCode)
             throws URISyntaxException, IOException, InterruptedException {
+
+        String privateKeyJWT = getPrivateKeyJWT(authorizationCode.trim());
 
         var request =
                 HttpRequest.newBuilder()
-                        .uri(
-                                new URIBuilder(getPrivateApiEndpoint())
-                                        .setPath(devAccessTokenUri)
-                                        .build())
+                        .uri(new URIBuilder(getPrivateApiEndpoint()).setPath("/dev/token").build())
                         .header("Content-Type", "application/x-www-form-urlencoded")
                         .header("x-api-key", getPublicAPIKey())
                         .POST(HttpRequest.BodyPublishers.ofString(privateKeyJWT))
@@ -153,7 +151,7 @@ public class IpvCoreStubUtil {
         return sendHttpRequest(request);
     }
 
-    public static String getPrivateKeyJWT(String authorizationCode)
+    private static String getPrivateKeyJWT(String authorizationCode)
             throws URISyntaxException, IOException, InterruptedException {
         return getPrivateKeyJWTFormParamsForAuthCode(getIPVCoreStubURL(), authorizationCode.trim());
     }
@@ -173,12 +171,10 @@ public class IpvCoreStubUtil {
     }
 
     private static String getPublicAPIKey() {
-        return Optional.ofNullable(System.getenv("APIGW_API_KEY"))
+        return Optional.ofNullable(System.getenv("PUBLIC_API_KEY"))
                 .orElseThrow(
                         () ->
                                 new IllegalArgumentException(
-                                        String.format(
-                                                "Environment variable %s is not assigned",
-                                                "APIGW_API_KEY")));
+                                        "PUBLIC_API_KEY environment variable is not assigned"));
     }
 }

--- a/integration-tests/src/test/resources/features/AccessTokenAPI.feature
+++ b/integration-tests/src/test/resources/features/AccessTokenAPI.feature
@@ -1,0 +1,36 @@
+Feature: Access Token API
+
+  Background: a session id is returned
+    Given authorization JAR for test user 681
+    When user sends a request to session API
+    Then user gets a session id
+    When user sends a valid request to authorization end point
+    Then expect a status code of 200 in the response
+    And a valid authorization code is returned in the response
+
+  Scenario: access token is returned
+    When user sends a request to access token end point
+    Then expect a status code of 200 in the response
+    And a valid access token is returned in the response
+
+  Scenario Outline: no access token is returned when request parameters are missing
+    When user sends a request to access token end point with missing "<parameter>"
+    Then expect a status code of 400 in the response
+    And a "Token validation error" error with code 1023 is sent in the response
+    Examples:
+      | parameter             |
+      | code                  |
+      | client_assertion_type |
+      | redirect_uri          |
+      | client_assertion      |
+      | grant_type            |
+
+  Scenario: no access token is returned when request has invalid grant_type
+    When user sends a request to access token end point with incorrect grant type
+    Then expect a status code of 400 in the response
+    And a "Token validation error" error with code 1023 is sent in the response
+
+  Scenario: no access token is returned when request has invalid authorization code
+    When user sends a request to access token end point with incorrect authorization code
+    Then expect a status code of 403 in the response
+    And a "Access token expired" error with code 1026 is sent in the response

--- a/integration-tests/src/test/resources/features/AccessTokenAPI.feature
+++ b/integration-tests/src/test/resources/features/AccessTokenAPI.feature
@@ -13,23 +13,6 @@ Feature: Access Token API
     Then expect a status code of 200 in the response
     And a valid access token is returned in the response
 
-  Scenario Outline: no access token is returned when request parameters are missing
-    When user sends a request to access token end point with missing "<parameter>"
-    Then expect a status code of 400 in the response
-    And a "Token validation error" error with code 1023 is sent in the response
-    Examples:
-      | parameter             |
-      | code                  |
-      | client_assertion_type |
-      | redirect_uri          |
-      | client_assertion      |
-      | grant_type            |
-
-  Scenario: no access token is returned when request has invalid grant_type
-    When user sends a request to access token end point with incorrect grant type
-    Then expect a status code of 400 in the response
-    And a "Token validation error" error with code 1023 is sent in the response
-
   Scenario: no access token is returned when request has invalid authorization code
     When user sends a request to access token end point with incorrect authorization code
     Then expect a status code of 403 in the response

--- a/integration-tests/src/test/resources/features/AuthorizationAPI.feature
+++ b/integration-tests/src/test/resources/features/AuthorizationAPI.feature
@@ -13,9 +13,9 @@ Feature: Authorization API
   Scenario: no authorization code is returned when client id does not match
     When user sends a request to authorization end point with invalid client id
     Then expect a status code of 400 in the response
-    And a "Session Validation Exception" error with code 1019 is sent in the response body
+    And a "Session Validation Exception" error with code 1019 is sent in the response
 
   Scenario: no authorization code is returned when redirect uri does not match
     When user sends a request to authorization end point with invalid redirect uri
     Then expect a status code of 400 in the response
-    And a "Session Validation Exception" error with code 1019 is sent in the response body
+    And a "Session Validation Exception" error with code 1019 is sent in the response


### PR DESCRIPTION
### Requirement
Add cucumber integration test to the `di-ipv-cri-common-lambdas` for `access token` end point

### Important considerations:
- It is imperative to call the `session` and `authorization` end points before invoking the `access token` end point

### What changed
- Added new `feature` file for Access Token end point
- New steps added to the `APISteps` file

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1014](https://govukverify.atlassian.net/browse/OJ-1014)

### Other considerations
To run the tests:

`STACK_NAME=di-ipv-cri-address-xxxx API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" APIGW_API_KEY=xxxx gradle integration-tests:cucumber`

