### PR TITLE
OJ-993 - log govuk_signin_journey_id

### DIFF
--- a/accesstoken/build.gradle
+++ b/accesstoken/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id "java"
 	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
+	id 'jacoco'
 }
 
 dependencies {
@@ -15,7 +16,13 @@ dependencies {
 	testImplementation configurations.tests
 	testRuntimeOnly configurations.test_runtime
 }
-
 test {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required.set(true)
+	}
 }

--- a/accesstoken/src/main/java/uk/gov/di/ipv/cri/common/api/handler/AccessTokenHandler.java
+++ b/accesstoken/src/main/java/uk/gov/di/ipv/cri/common/api/handler/AccessTokenHandler.java
@@ -46,7 +46,7 @@ public class AccessTokenHandler
     }
 
     @Override
-    @Logging(correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST)
+    @Logging(correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST, clearState = true)
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
@@ -54,6 +54,9 @@ public class AccessTokenHandler
             TokenRequest tokenRequest = accessTokenService.createTokenRequest(input.getBody());
             String authCode = accessTokenService.getAuthorizationCode(tokenRequest);
             SessionItem sessionItem = sessionService.getSessionByAuthorisationCode(authCode);
+            eventProbe
+                    .addJourneyIdToLoggingContext(sessionItem.getClientSessionId())
+                    .log(Level.INFO, "found session");
             accessTokenService.validateTokenRequest(tokenRequest, sessionItem);
             AccessTokenResponse accessTokenResponse = accessTokenService.createToken(tokenRequest);
             accessTokenService.updateSessionAccessToken(sessionItem, accessTokenResponse);

--- a/authorization/src/test/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandlerTest.java
+++ b/authorization/src/test/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandlerTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,8 +16,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.common.api.service.AuthorizationValidatorService;
+import uk.gov.di.ipv.cri.common.library.exception.SessionValidationException;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
-import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
@@ -28,118 +29,128 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthorizationHandlerTest {
+    private static final String FOUND_SESSION_LOG_MESSAGE = "found session";
+    private static final String SESSION_ID = UUID.randomUUID().toString();
 
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
     @Mock private SessionService mockSessionService;
     @Mock private AuthorizationValidatorService mockAuthorizationValidatorService;
     @Mock private APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent;
-    @Mock private EventProbe eventProbe;
+    @Mock private EventProbe mockEventProbe;
     @InjectMocks private AuthorizationHandler authorizationHandler;
 
     @Test
     void shouldReturn200AndCreateAuthorisationSuccessfully() throws JsonProcessingException {
+        String redirectUri = "https://example.com";
+        String authCode = "auth-code";
+        String state = "state-ipv";
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://example.com");
+        params.put("redirect_uri", redirectUri);
         params.put("client_id", "ipv-core");
         params.put("response_type", "code");
         params.put("scope", "openid");
-        params.put("state", "state-ipv");
+        params.put("state", state);
         when(apiGatewayProxyRequestEvent.getQueryStringParameters()).thenReturn(params);
-        UUID sessionId = UUID.randomUUID();
-        when(apiGatewayProxyRequestEvent.getHeaders())
-                .thenReturn(Map.of("session-id", sessionId.toString()));
+
+        when(apiGatewayProxyRequestEvent.getHeaders()).thenReturn(Map.of("session-id", SESSION_ID));
 
         SessionItem mockSessionItem = mock(SessionItem.class);
+        when(mockSessionItem.getAuthorizationCode()).thenReturn(authCode);
+        when(mockSessionItem.getClientSessionId()).thenReturn(SESSION_ID);
 
-        when(mockSessionItem.getAuthorizationCode()).thenReturn("auth-code");
+        when(mockSessionService.getSession(SESSION_ID)).thenReturn(mockSessionItem);
 
-        when(mockSessionService.getSession(sessionId.toString())).thenReturn(mockSessionItem);
-
-        when(eventProbe.counterMetric(anyString())).thenReturn(eventProbe);
-        when(eventProbe.auditEvent(any())).thenReturn(eventProbe);
+        when(mockEventProbe.addJourneyIdToLoggingContext(SESSION_ID)).thenReturn(mockEventProbe);
+        when(mockEventProbe.log(Level.INFO, FOUND_SESSION_LOG_MESSAGE)).thenReturn(mockEventProbe);
+        when(mockEventProbe.counterMetric(anyString())).thenReturn(mockEventProbe);
+        when(mockEventProbe.auditEvent(any())).thenReturn(mockEventProbe);
 
         APIGatewayProxyResponseEvent responseEvent =
                 authorizationHandler.handleRequest(apiGatewayProxyRequestEvent, null);
         assertNotNull(responseEvent.getBody());
-        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        JsonNode node = objectMapper.readTree(responseEvent.getBody());
-        assertEquals("http://example.com", node.get("redirectionURI").textValue());
-        assertEquals("state-ipv", node.get("state").get("value").textValue());
-        assertEquals("auth-code", node.get("authorizationCode").get("value").textValue());
 
-        verify(mockSessionService).getSession(sessionId.toString());
-        verify(eventProbe).counterMetric(anyString());
-        verify(eventProbe).auditEvent(any());
+        JsonNode node = objectMapper.readTree(responseEvent.getBody());
+        assertEquals(redirectUri, node.get("redirectionURI").textValue());
+        assertEquals(state, node.get("state").get("value").textValue());
+        assertEquals(authCode, node.get("authorizationCode").get("value").textValue());
+
+        verify(mockSessionService).getSession(SESSION_ID);
+        verify(mockAuthorizationValidatorService)
+                .validate(any(AuthenticationRequest.class), eq(mockSessionItem));
+        verify(mockEventProbe).addJourneyIdToLoggingContext(SESSION_ID);
+        verify(mockEventProbe).log(Level.INFO, FOUND_SESSION_LOG_MESSAGE);
+        verify(mockEventProbe).counterMetric(anyString());
+        verify(mockEventProbe).auditEvent(any());
     }
 
     @Test
     void shouldThrowServerExceptionWhenScopeParamIsMissing() throws JsonProcessingException {
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://example.com");
+        params.put("redirect_uri", "https://example.com");
         params.put("client_id", "ipv-core");
         params.put("response_type", "code");
         params.put("state", "state-ipv");
         when(apiGatewayProxyRequestEvent.getQueryStringParameters()).thenReturn(params);
 
-        when(eventProbe.log(any(Level.class), any(Exception.class))).thenReturn(eventProbe);
+        when(mockEventProbe.log(any(Level.class), any(Exception.class))).thenReturn(mockEventProbe);
 
         APIGatewayProxyResponseEvent response =
                 authorizationHandler.handleRequest(apiGatewayProxyRequestEvent, null);
-        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
         Map<String, Object> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
         assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertEquals(1020, responseBody.get("code"));
         assertEquals("Server Configuration Error", responseBody.get("message"));
-
-        verify(eventProbe).log(any(Level.class), any(Exception.class));
+        verify(mockEventProbe).log(eq(Level.ERROR), any(Exception.class));
     }
 
     @Test
-    void shouldThrowSessionValidationExceptionWhenClientIDDoesNotMatch()
-            throws JsonProcessingException {
+    void shouldReturnBadRequestWhenSessionValidationFails() throws JsonProcessingException {
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://example.com");
+        params.put("redirect_uri", "https://example.com");
         params.put("client_id", "ipv-core");
         params.put("response_type", "code");
         params.put("scope", "openid");
         params.put("state", "state-ipv");
         when(apiGatewayProxyRequestEvent.getQueryStringParameters()).thenReturn(params);
-        UUID sessionId = UUID.randomUUID();
-        when(apiGatewayProxyRequestEvent.getHeaders())
-                .thenReturn(Map.of("session-id", sessionId.toString()));
+
+        when(apiGatewayProxyRequestEvent.getHeaders()).thenReturn(Map.of("session-id", SESSION_ID));
 
         SessionItem mockSessionItem = mock(SessionItem.class);
-        when(mockSessionItem.getClientId()).thenReturn("wrong-client-id");
-        when(mockSessionService.getSession(sessionId.toString())).thenReturn(mockSessionItem);
+        when(mockSessionItem.getClientSessionId()).thenReturn(SESSION_ID);
 
-        when(eventProbe.log(any(Level.class), any(Exception.class))).thenReturn(eventProbe);
+        when(mockSessionService.getSession(SESSION_ID)).thenReturn(mockSessionItem);
 
-        ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
-        HashMap<String, String> parameters = new HashMap<>();
-        parameters.put("redirectUri", "https://www.example/com/callback");
+        when(mockEventProbe.log(Level.INFO, FOUND_SESSION_LOG_MESSAGE)).thenReturn(mockEventProbe);
+        when(mockEventProbe.addJourneyIdToLoggingContext(SESSION_ID)).thenReturn(mockEventProbe);
+        when(mockEventProbe.log(eq(Level.ERROR), any(SessionValidationException.class)))
+                .thenReturn(mockEventProbe);
 
-        AuthorizationValidatorService validatorService =
-                new AuthorizationValidatorService(mockConfigurationService);
-        AuthorizationHandler authorizationHandler =
-                new AuthorizationHandler(mockSessionService, eventProbe, validatorService);
+        doThrow(new SessionValidationException("test exception"))
+                .when(mockAuthorizationValidatorService)
+                .validate(any(AuthenticationRequest.class), eq(mockSessionItem));
 
         APIGatewayProxyResponseEvent response =
                 authorizationHandler.handleRequest(apiGatewayProxyRequestEvent, null);
 
-        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         Map<String, Object> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
         assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
         assertEquals(1019, responseBody.get("code"));
         assertEquals("Session Validation Exception", responseBody.get("message"));
 
-        verify(mockSessionService).getSession(sessionId.toString());
-        verify(eventProbe).log(any(Level.class), any(Exception.class));
+        verify(mockSessionService).getSession(SESSION_ID);
+        verify(mockEventProbe).log(Level.INFO, FOUND_SESSION_LOG_MESSAGE);
+        verify(mockEventProbe).log(eq(Level.ERROR), any(SessionValidationException.class));
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.1.6"
+		cri_common_lib           : "1.3.0"
 	]
 }
 


### PR DESCRIPTION
### What changed
- Log `govuk_signin_journey_id`

### Why did it change
- To align with the logging already present in `address-api` and help with debugging / understanding live user journeys

### Issue tracking
- [OJ-993](https://govukverify.atlassian.net/browse/OJ-993)
