### PR TITLE
F2F-136: Adding the CIC CRI to the GitHub workflows

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   publish_common_cri_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, CIC_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
@@ -27,6 +27,10 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: KBV_POC_SIGNING_PROFILE_NAME
+          - target: CIC_DEV
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: CIC_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: CIC_DEV_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to dev
     runs-on: ubuntu-latest
@@ -87,7 +91,7 @@ jobs:
     needs: publish_common_cri_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, CIC_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
@@ -101,6 +105,10 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    KBV_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: KBV_BUILD_SIGNING_PROFILE_NAME
+          - target: CIC_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:    CIC_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: CIC_BUILD_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to build
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,44 +168,72 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "43f4abcd5d5e2cf1482fbda5bf4eadcdfc0a294c",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "64ababf589be883e6d09e73b1c050566f76aeb0f",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d9c4666052c745e7c6f573d794aca9a4a6f3be8e",
-        "is_verified": false,
-        "line_number": 93
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
-        "is_verified": false,
-        "line_number": 94
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
         "line_number": 97
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
+        "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
         "is_verified": false,
         "line_number": 98
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
+        "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
         "line_number": 101
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
+        "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
         "is_verified": false,
         "line_number": 102
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "a526684ba66fb0f1d7c1bd531c70f1bf14db6a6a",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "0aa77508d48646456f474415968125a444b86312",
+        "is_verified": false,
+        "line_number": 110
       }
     ],
     ".github/workflows/pre-merge-integration-test.yml": [
@@ -289,5 +317,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-08T10:21:26Z"
+  "generated_at": "2022-12-07T14:16:32Z"
 }


### PR DESCRIPTION
## Proposed changes

### What changed
The CIC CRI is added to the list of CRIs in the GitHub post-merge-matrix-deploy workflow.

New secrets are referenced, which will need to be added to this repo.

### Why did it change
To allow for deployment of the Common infrastructure pipeline in the F2F AWS accounts.

### Issue tracking
- [F2F-136](https://govukverify.atlassian.net/browse/F2F-136)

## Checklists

### Other considerations