### PR TITLE
Add CIC CRI configuration (for the F2F / kiwi team)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -232,28 +236,28 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "407b058c0f67be53116117c4b021b5e95f9dca9e",
         "is_verified": false,
-        "line_number": 177
+        "line_number": 188
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "486b0e17dde4271451ce7c815378fab9081085d1",
         "is_verified": false,
-        "line_number": 188
+        "line_number": 199
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "81249afd017322b40765e849988f74ebc18e757c",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 200
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "54ec3197768e4b02c47ff91d4858f80b0c6fad30",
         "is_verified": false,
-        "line_number": 190
+        "line_number": 201
       }
     ],
     "session/src/test/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypterTest.java": [
@@ -289,5 +293,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-08T10:21:26Z"
+  "generated_at": "2022-12-19T11:39:27Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -126,6 +126,11 @@ Mappings:
       build: "https://review-d.build.account.gov.uk"
       staging: "https://review-d.staging.account.gov.uk"
       integration: "https://review-d.integration.account.gov.uk"
+    di-ipv-cri-cic-api:
+      dev: "https://review-c.dev.account.gov.uk"
+      build: "https://review-c.build.account.gov.uk"
+      staging: "https://review-c.staging.account.gov.uk"
+      integration: "https://review-c.integration.account.gov.uk"
 
   IPVCoreStubPreProdAudienceMapping:
     di-ipv-cri-address-api:
@@ -136,6 +141,8 @@ Mappings:
       production: "https://review-k.account.gov.uk"
     di-ipv-cri-driving-permit-api:
       production: "https://review-d.account.gov.uk"
+    di-ipv-cri-cic-api:
+      production: "https://review-c.account.gov.uk"
 
   IPVCore1AudienceMapping:
     di-ipv-cri-address-api:
@@ -154,6 +161,10 @@ Mappings:
       staging: "https://review-d.staging.account.gov.uk"
       integration: "https://review-d.integration.account.gov.uk"
       production: "https://review-d.account.gov.uk"
+    di-ipv-cri-cic-api:
+      staging: "https://review-c.staging.account.gov.uk"
+      integration: "https://review-c.integration.account.gov.uk"
+      production: "https://review-c.account.gov.uk"
 
   IPVCoreStubIssuerMapping:
     Environment:
@@ -217,6 +228,10 @@ Mappings:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=driving-permit"
       integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=driving-permit"
       production: "https://identity.account.gov.uk/credential-issuer/callback?id=driving-permit"
+    di-ipv-cri-cic-api:
+      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=cic"
+      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=cic"
+      production: "https://identity.account.gov.uk/credential-issuer/callback?id=cic"
 
   VerifiableCredentialIssuerMapping:
     di-ipv-cri-address-api:
@@ -243,6 +258,12 @@ Mappings:
       staging: "https://review-d.staging.account.gov.uk"
       integration: "https://review-d.integration.account.gov.uk"
       production: "https://review-d.account.gov.uk"
+    di-ipv-cri-cic-api:
+      dev: "https://review-c.dev.account.gov.uk"
+      build: "https://review-c.build.account.gov.uk"
+      staging: "https://review-c.staging.account.gov.uk"
+      integration: "https://review-c.integration.account.gov.uk"
+      production: "https://review-c.account.gov.uk"
 
 Resources:
   SessionFunction:


### PR DESCRIPTION
### What changed
- New infra mappings added for the CIC CRI

### Why did it change
- To enable the deployment of a common-lambdas AWS stack for the F2F / kiwi team development work on the CIC CRI
