### PR TITLE
OJ-1146 update custom output

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: "detect-secrets --all-files"

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: zulu
           cache: 'gradle'
       - name: Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/
@@ -59,7 +59,7 @@ jobs:
           distribution: zulu
           cache: 'gradle'
       - name: Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/
@@ -80,7 +80,7 @@ jobs:
             */build/reports/
           retention-days: 5
       - name: Cache Unit Test Reports
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
@@ -101,7 +101,7 @@ jobs:
           distribution: zulu
           cache: 'gradle'
       - name: Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/
@@ -110,7 +110,7 @@ jobs:
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Cache Unit Test Reports
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Set short SHA
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: SAM deploy integration test stack
         run: |


### PR DESCRIPTION
## Proposed changes

### What changed

Custom workflow step changed from using set-output to be out of scope of GitHub deprecations

### Why did it change

The workflow will fail soon if this is not changed

### Issue tracking

- [OJ-1146](https://govukverify.atlassian.net/browse/OJ-1146)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1146]: https://govukverify.atlassian.net/browse/OJ-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ