### PR TITLE
LIME-421: Renamed driving permit to DL

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -121,7 +121,7 @@ Mappings:
       build: "https://review-k.build.account.gov.uk"
       staging: "https://review-k.staging.account.gov.uk"
       integration: "https://review-k.integration.account.gov.uk"
-    di-ipv-cri-driving-permit-api:
+    di-ipv-cri-dl-api:
       dev: "https://review-d.dev.account.gov.uk"
       build: "https://review-d.build.account.gov.uk"
       staging: "https://review-d.staging.account.gov.uk"
@@ -139,7 +139,7 @@ Mappings:
       production: "https://review-f.account.gov.uk"
     di-ipv-cri-kbv-api:
       production: "https://review-k.account.gov.uk"
-    di-ipv-cri-driving-permit-api:
+    di-ipv-cri-dl-api:
       production: "https://review-d.account.gov.uk"
     di-ipv-cri-cic-api:
       production: "https://review-c.account.gov.uk"
@@ -157,7 +157,7 @@ Mappings:
       staging: "https://review-k.staging.account.gov.uk"
       integration: "https://review-k.integration.account.gov.uk"
       production: "https://review-k.account.gov.uk"
-    di-ipv-cri-driving-permit-api:
+    di-ipv-cri-dl-api:
       staging: "https://review-d.staging.account.gov.uk"
       integration: "https://review-d.integration.account.gov.uk"
       production: "https://review-d.account.gov.uk"
@@ -224,7 +224,7 @@ Mappings:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv"
       integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=kbv"
       production: "https://identity.account.gov.uk/credential-issuer/callback?id=kbv"
-    di-ipv-cri-driving-permit-api:
+    di-ipv-cri-dl-api:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=driving-permit"
       integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=driving-permit"
       production: "https://identity.account.gov.uk/credential-issuer/callback?id=driving-permit"
@@ -252,7 +252,7 @@ Mappings:
       staging: "https://review-k.staging.account.gov.uk"
       integration: "https://review-k.integration.account.gov.uk"
       production: "https://review-k.account.gov.uk"
-    di-ipv-cri-driving-permit-api:
+    di-ipv-cri-dl-api:
       dev: "https://review-d.dev.account.gov.uk"
       build: "https://review-d.build.account.gov.uk"
       staging: "https://review-d.staging.account.gov.uk"


### PR DESCRIPTION
## Proposed changes

### What changed

Renamed driving permit to dl in lambda names

### Why did it change

Driving permit was renamed to DL after this was created as the name was too long for aws

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-421](https://govukverify.atlassian.net/browse/LIME-421)



[LIME-421]: https://govukverify.atlassian.net/browse/LIME-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ