### PR TITLE
BAU: Remove public Api key

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -67,7 +67,6 @@ jobs:
           IPV_CORE_STUB_URL: https://di-ipv-core-stub.london.cloudapps.digital
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}
-          PUBLIC_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
         run: |
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
           API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PreMergeDevOnlyApiId").OutputValue')

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -144,7 +144,6 @@ public class IpvCoreStubUtil {
                 HttpRequest.newBuilder()
                         .uri(new URIBuilder(getPrivateApiEndpoint()).setPath("/dev/token").build())
                         .header("Content-Type", "application/x-www-form-urlencoded")
-                        .header("x-api-key", getPublicAPIKey())
                         .POST(HttpRequest.BodyPublishers.ofString(privateKeyJWT))
                         .build();
 
@@ -168,13 +167,5 @@ public class IpvCoreStubUtil {
 
         HttpRequest request = HttpRequest.newBuilder().uri(url).GET().build();
         return sendHttpRequest(request).body();
-    }
-
-    private static String getPublicAPIKey() {
-        return Optional.ofNullable(System.getenv("PUBLIC_API_KEY"))
-                .orElseThrow(
-                        () ->
-                                new IllegalArgumentException(
-                                        "PUBLIC_API_KEY environment variable is not assigned"));
     }
 }


### PR DESCRIPTION
Api key is only used for non dev enviroments and not required for dev as a result it is also not required during pre-merge tes

## Proposed changes

Remove the specification of public api key as an environment variable

### What changed

Corresponding environment variable removed  

### Why did it change

Discovered during QA exploration of how to run the common lambda api from the commandline

### Environment variables or secrets

Removed `PUBLIC_API_KEY` environment variable

### Other considerations

The github secret value associated with this value should also be removed