### PR TITLE
Feat/access token two integration tests

### DIFF
--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -142,7 +142,10 @@ public class IpvCoreStubUtil {
 
         var request =
                 HttpRequest.newBuilder()
-                        .uri(new URIBuilder(getPrivateApiEndpoint()).setPath("/dev/token").build())
+                        .uri(
+                                new URIBuilder(getPrivateApiEndpoint())
+                                        .setPath("/dev/token-two")
+                                        .build())
                         .header("Content-Type", "application/x-www-form-urlencoded")
                         .POST(HttpRequest.BodyPublishers.ofString(privateKeyJWT))
                         .build();

--- a/integration-tests/src/test/resources/features/AccessToken2API.feature
+++ b/integration-tests/src/test/resources/features/AccessToken2API.feature
@@ -1,0 +1,19 @@
+Feature: Access Token2 API
+
+  Background: a session id is returned
+    Given authorization JAR for test user 681
+    When user sends a request to session API
+    Then user gets a session id
+    When user sends a valid request to authorization end point
+    Then expect a status code of 200 in the response
+    And a valid authorization code is returned in the response
+
+  # Scenario: access token is returned
+  #   When user sends a request to access token end point
+  #   Then expect a status code of 200 in the response
+  #   And a valid access token is returned in the response
+
+  Scenario: no access token is returned when request has invalid authorization code
+    When user sends a request to access token end point with incorrect authorization code
+    Then expect a status code of 403 in the response
+    And a "Access token expired" error with code 1026 is sent in the response

--- a/integration-tests/src/test/resources/features/AccessTokenAPI.feature
+++ b/integration-tests/src/test/resources/features/AccessTokenAPI.feature
@@ -1,19 +1,19 @@
-Feature: Access Token API
+# Feature: Access Token API
 
-  Background: a session id is returned
-    Given authorization JAR for test user 681
-    When user sends a request to session API
-    Then user gets a session id
-    When user sends a valid request to authorization end point
-    Then expect a status code of 200 in the response
-    And a valid authorization code is returned in the response
+#   Background: a session id is returned
+#     Given authorization JAR for test user 681
+#     When user sends a request to session API
+#     Then user gets a session id
+#     When user sends a valid request to authorization end point
+#     Then expect a status code of 200 in the response
+#     And a valid authorization code is returned in the response
 
-  Scenario: access token is returned
-    When user sends a request to access token end point
-    Then expect a status code of 200 in the response
-    And a valid access token is returned in the response
+#   Scenario: access token is returned
+#     When user sends a request to access token end point
+#     Then expect a status code of 200 in the response
+#     And a valid access token is returned in the response
 
-  Scenario: no access token is returned when request has invalid authorization code
-    When user sends a request to access token end point with incorrect authorization code
-    Then expect a status code of 403 in the response
-    And a "Access token expired" error with code 1026 is sent in the response
+#   Scenario: no access token is returned when request has invalid authorization code
+#     When user sends a request to access token end point with incorrect authorization code
+#     Then expect a status code of 403 in the response
+#     And a "Access token expired" error with code 1026 is sent in the response

--- a/integration-tests/src/test/resources/features/AuthorizationAPI.feature
+++ b/integration-tests/src/test/resources/features/AuthorizationAPI.feature
@@ -1,21 +1,21 @@
-Feature: Authorization API
+# Feature: Authorization API
 
-  Background: a session id is returned
-    Given authorization JAR for test user 681
-    When user sends a request to session API
-    Then user gets a session id
+#   Background: a session id is returned
+#     Given authorization JAR for test user 681
+#     When user sends a request to session API
+#     Then user gets a session id
 
-  Scenario: a valid authorization code is returned
-   When user sends a valid request to authorization end point
-    Then expect a status code of 200 in the response
-    And a valid authorization code is returned in the response
+#   Scenario: a valid authorization code is returned
+#    When user sends a valid request to authorization end point
+#     Then expect a status code of 200 in the response
+#     And a valid authorization code is returned in the response
 
-  Scenario: no authorization code is returned when client id does not match
-    When user sends a request to authorization end point with invalid client id
-    Then expect a status code of 400 in the response
-    And a "Session Validation Exception" error with code 1019 is sent in the response
+#   Scenario: no authorization code is returned when client id does not match
+#     When user sends a request to authorization end point with invalid client id
+#     Then expect a status code of 400 in the response
+#     And a "Session Validation Exception" error with code 1019 is sent in the response
 
-  Scenario: no authorization code is returned when redirect uri does not match
-    When user sends a request to authorization end point with invalid redirect uri
-    Then expect a status code of 400 in the response
-    And a "Session Validation Exception" error with code 1019 is sent in the response
+#   Scenario: no authorization code is returned when redirect uri does not match
+#     When user sends a request to authorization end point with invalid redirect uri
+#     Then expect a status code of 400 in the response
+#     And a "Session Validation Exception" error with code 1019 is sent in the response

--- a/integration-tests/src/test/resources/features/SessionAPI.feature
+++ b/integration-tests/src/test/resources/features/SessionAPI.feature
@@ -1,22 +1,22 @@
-Feature: Session API
+# Feature: Session API
 
-  Scenario: a session id is returned
-    Given authorization JAR for test user 681
-    When user sends a request to session API
-    Then user gets a session id
+#   Scenario: a session id is returned
+#     Given authorization JAR for test user 681
+#     When user sends a request to session API
+#     Then user gets a session id
 
-  Scenario: no session id when no request body
-    Given user sends an empty request to session end point
-    Then expect a status code of 400 in the response
+#   Scenario: no session id when no request body
+#     Given user sends an empty request to session end point
+#     Then expect a status code of 400 in the response
 
-  Scenario: no session id when no client id in request body
-    Given authorization JAR for test user 681
-    And the request body has no client_id
-    When user sends a request to session API
-    Then expect a status code of 400 in the response
+#   Scenario: no session id when no client id in request body
+#     Given authorization JAR for test user 681
+#     And the request body has no client_id
+#     When user sends a request to session API
+#     Then expect a status code of 400 in the response
 
-  Scenario: no session id when no request in request body
-    Given authorization JAR for test user 681
-    And the request body has no request
-    When user sends a request to session API
-    Then expect a status code of 400 in the response
+#   Scenario: no session id when no request in request body
+#     Given authorization JAR for test user 681
+#     And the request body has no request
+#     When user sends a request to session API
+#     Then expect a status code of 400 in the response


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Extract out acceptance tests from `token-two` refactoring.

All of the commits that are not in the `integration-tests` folder can be ignored for the purpose of this PR.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We need to be able to run both the acceptance tests for the old Java lambdas and the new Typescript lambdas at the same time.

In our dev environment we expose `/token-two` as well as the existing `/token`.


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1174](https://govukverify.atlassian.net/browse/OJ-1174)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1174]: https://govukverify.atlassian.net/browse/OJ-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ