### PR TITLE
BAU: Rename AccessTokenService to BearerAccessTokenFactory

### DIFF
--- a/lambdas/src/services/bearer-access-token-factory.ts
+++ b/lambdas/src/services/bearer-access-token-factory.ts
@@ -1,7 +1,8 @@
 import { BearerAccessToken } from "../types/bearer-access-token";
 
-export class AccessTokenService {
-    public async createBearerAccessToken(expires_in: number): Promise<BearerAccessToken> {
+export class BearerAccessTokenFactory {
+    constructor(private bearerAccessTokenTtl: number) {}
+    public async create(): Promise<BearerAccessToken> {
         const { randomBytes } = await import("node:crypto");
 
         const token_type = "Bearer";
@@ -10,7 +11,7 @@ export class AccessTokenService {
         return {
             access_token,
             token_type,
-            expires_in,
+            expires_in: this.bearerAccessTokenTtl,
         };
     }
 }

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -1,7 +1,6 @@
 import { JwtVerificationConfig } from "../../../src/types/jwt-verification-config";
 import { AccessTokenLambda } from "../../../src/handlers/access-token-handler";
 import { ConfigService } from "../../../src/common/config/config-service";
-import { AccessTokenService } from "../../../src/services/access-token-service";
 import { AccessTokenRequestValidator } from "../../../src/services/token-request-validator";
 import { SessionService } from "../../../src/services/session-service";
 import { APIGatewayProxyEvent } from "aws-lambda/trigger/api-gateway-proxy";
@@ -10,6 +9,7 @@ import { JwtVerifier, JwtVerifierFactory } from "../../../src/common/security/jw
 import { Logger } from "@aws-lambda-powertools/logger";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import { SessionItem } from "../../../src/types/session-item";
+import { BearerAccessTokenFactory } from "../../../src/services/bearer-access-token-factory";
 
 jest.mock("../../../src/common/config/config-service");
 jest.mock("../../../src/common/security/jwt-verifier");
@@ -52,7 +52,7 @@ describe("access-token-handler.ts", () => {
         const jwtVerifier = new JwtVerifier(jwtVerificationConfig, logger);
         const mockJwtVerifierFactory = jest.mocked(JwtVerifierFactory);
         const mockConfigService = jest.mocked(ConfigService);
-        const accessTokenService = new AccessTokenService();
+        const accessTokenService = new BearerAccessTokenFactory(10);
         const sessionService = new SessionService(mockDynamoDbClient.prototype, configService);
         const accessTokenRequestValidator = new AccessTokenRequestValidator(mockJwtVerifierFactory.prototype);
 

--- a/lambdas/tests/unit/services/bearer-access-token-factory.test.ts
+++ b/lambdas/tests/unit/services/bearer-access-token-factory.test.ts
@@ -1,16 +1,16 @@
-import { AccessTokenService } from "../../../src/services/access-token-service";
+import { BearerAccessTokenFactory } from "../../../src/services/bearer-access-token-factory";
 
 describe("access-token-service", () => {
-    let accessTokenService: AccessTokenService;
+    let bearerAccessTokenFactory: BearerAccessTokenFactory;
 
     describe("createBearerAccessToken", () => {
         beforeEach(() => {
             jest.resetAllMocks();
-            accessTokenService = new AccessTokenService();
+            bearerAccessTokenFactory = new BearerAccessTokenFactory(10);
         });
 
         it("should return a bearer token when provided with an expires value", async () => {
-            const output = await accessTokenService.createBearerAccessToken(10);
+            const output = await bearerAccessTokenFactory.create();
             expect(output.token_type).toBe("Bearer");
             expect(output.expires_in).toBe(10);
             const token = Buffer.from(output.access_token, "base64url");


### PR DESCRIPTION
## Proposed changes

Rename Service to Factory

### What changed

Renamed the AccessTokenService to BearerAccessTokenFactory

### Why did it change

AccessTokenService returns a bearerAccesstoken object

