### PR TITLE
OJ-1224: Add unit test for auth request validator

### DIFF
--- a/lambdas/src/services/auth-request-validator.ts
+++ b/lambdas/src/services/auth-request-validator.ts
@@ -2,11 +2,12 @@ import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda/trigger/ap
 import { ValidationResult } from "../types/validation-result";
 
 export class AuthorizationRequestValidator {
-    async validate(
+    validate(
         queryStringParams: APIGatewayProxyEventQueryStringParameters | null,
         sessionClientId: string,
         expectedRedirectUri: string,
-    ): Promise<ValidationResult> {
+    ): ValidationResult {
+        
         if (!queryStringParams) {
             return { isValid: false, errorMsg: "Missing querystring parameters" };
         }
@@ -18,19 +19,19 @@ export class AuthorizationRequestValidator {
         if (!clientId) {
             errorMsg = "Missing client_id parameter";
         }
-        if (!redirectUri) {
+        else if (!redirectUri) {
             errorMsg = "Missing redirect_uri parameter";
         }
-        if (!responseType) {
+        else if (!responseType) {
             errorMsg = "Missing response_type parameter";
         }
-        if (clientId !== sessionClientId) {
+        else if (clientId !== sessionClientId) {
             errorMsg = "Invalid client_id parameter";
         }
-        if (redirectUri !== expectedRedirectUri) {
+        else if (redirectUri !== expectedRedirectUri) {
             errorMsg = "Invalid redirect_uri parameter";
         }
-
+        
         return { isValid: !errorMsg, errorMsg: errorMsg };
     }
 }

--- a/lambdas/tests/unit/services/auth-request-validator.test.ts
+++ b/lambdas/tests/unit/services/auth-request-validator.test.ts
@@ -1,0 +1,111 @@
+import { AuthorizationRequestValidator } from "../../../src/services/auth-request-validator";
+
+describe('auth-request-validator', () => {
+    describe('validate', () => {
+        let authRequestValidator: AuthorizationRequestValidator;
+        const existingClientId = "a-valid-clientId";
+        const configuredRedirectUri = "a-valid-redirect-uri";
+        beforeEach(() => {
+            authRequestValidator = new AuthorizationRequestValidator();
+        })
+        describe('no queryStringParams', () => {
+            it('should return missing querystring parameters', () => {
+                const validationResult = authRequestValidator.validate(null, existingClientId, configuredRedirectUri);
+                expect(validationResult).toEqual({
+                    isValid: false,
+                    errorMsg: "Missing querystring parameters"
+                })
+            });
+        });
+        describe('well-formed queryStringParams', () => {
+            let queryStringParams: any
+            beforeEach(() => {
+                queryStringParams = {
+                    client_id: "a-valid-clientId",
+                    redirect_uri: "a-valid-redirect-uri",
+                    response_type: "a-valid-response-type"
+                }
+            })
+
+            describe('with an existing client id and the configured redirect_uri', () => {
+                it('should return object true isValid attribute and null errorMsg', () => {
+                    const validationResult = authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
+                    expect(validationResult).toEqual({
+                        isValid: true,
+                        errorMsg: null
+                    });
+                });
+            });
+            describe('with a mismatched client id', () => {
+                it('should return invalid client id parameter error', () => {
+                    queryStringParams['client_id'] = "an-unexpected-clientId-in-the-request";
+
+                    const validationResult = authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
+                    expect(validationResult).toEqual({
+                        isValid: false,
+                        errorMsg: "Invalid client_id parameter"
+                    });
+                });
+            });
+            describe('with mismatching configured redirect_uri', () => {
+                it('should return invalid redirect uri parameter error', () => {
+                    queryStringParams["redirect_uri"] = "an-unexpected-redirect-uri-in-the-request";
+
+                    const validationResult = authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
+                    expect(validationResult).toEqual({
+                        isValid: false,
+                        errorMsg: "Invalid redirect_uri parameter"
+                    });
+                });
+            });
+            describe('client id and redirect_uri not matching', () => {
+                it('first invalid returned i.e. client_id uri parameter error', () => {
+                    queryStringParams["client_id"] = "an-unexpected-redirect-uri-in-the-request";
+                    queryStringParams["redirect_uri"] = "an-unexpected-redirect-uri-in-the-request";
+
+                    const validationResult = authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
+                    expect(validationResult).toEqual({
+                        isValid: false,
+                        errorMsg: "Invalid client_id parameter"
+                    });
+                });
+            });
+        });
+        describe('incomplete queryStringParam', () => {
+            describe('missing param attributes', () => {
+                let queryStringParams: any;
+                beforeEach(() => {
+                    queryStringParams = {};
+                });
+                it('should return missing client id parameter error', () => {
+                    queryStringParams["redirect_uri"] = "a-valid-redirect-uri",
+                        queryStringParams["response_type"] = "a-valid-response-type"
+
+                    const validationResult = authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
+                    expect(validationResult).toEqual({
+                        isValid: false,
+                        errorMsg: "Missing client_id parameter"
+                    });
+                });
+                it('should return missing redirect uri parameter error', () => {
+                    queryStringParams["client_id"] = "a-valid-clientId";
+                    queryStringParams["response_type"] = "a-valid-response-type";
+                    const validationResult = authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
+                    expect(validationResult).toEqual({
+                        isValid: false,
+                        errorMsg: "Missing redirect_uri parameter"
+                    });
+                });
+                it('should return missing response type parameter error', () => {
+                    queryStringParams["client_id"] = "a-valid-clientId";
+                    queryStringParams["redirect_uri"] = "a-valid-redirect-uri";
+                    const validationResult = authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
+                    expect(validationResult).toEqual({
+                        isValid: false,
+                        errorMsg: "Missing response_type parameter"
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Proposed changes

Unit test for Auth Request Validator - notice that the conditional have been adjust to return on first error. This is how the Java equivalent works as it throws as soon as something is wrong. Ideally we also want to throw as well. This PR is step towards this.

see: https://govukverify.atlassian.net/browse/OJ-1231


- [OJ-1224](https://govukverify.atlassian.net/browse/OJ-1224)



[OJ-1224]: https://govukverify.atlassian.net/browse/OJ-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ