### PR TITLE
chore: Run pretter as separate linting task

### DIFF
--- a/.github/workflows/pre-merge-checks-typescript.yml
+++ b/.github/workflows/pre-merge-checks-typescript.yml
@@ -26,8 +26,8 @@ jobs:
           node-version: 18.*
       - name: Install dependencies
         run: npm ci
-#      - name: Run lint
-#        run: npm run lint
+      - name: Run lint - prettier
+        run: npm run lint:prettier
       - name: Run tests with coverage
         run: npm run test
       - name: SonarCloud Scan

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -18,7 +18,9 @@
   },
   "scripts": {
       "unit": "jest --config=jest.config.ts",
-      "lint": "prettier --check src tests && eslint .",
+      "lint:prettier": "prettier --check src tests",
+      "lint:eslint": "eslint .",
+      "lint": "npm run lint:prettier && npm run lint:eslint",
       "compile": "tsc",
       "test": "npm run compile && npm run unit"
   },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add separate `prettier` task to GHA.

`eslitnt` is currently returning code violations, but `prettier` is already properly applied - so we should separate out these two tasks.
 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks