### PR TITLE
OJ-1231: use specific SessionValidationError

### DIFF
--- a/lambdas/src/common/utils/request-utils.ts
+++ b/lambdas/src/common/utils/request-utils.ts
@@ -1,4 +1,5 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
+import { InvalidRequestError } from "../../types/errors";
 
 const getHeaderValue = (event: APIGatewayProxyEvent, desiredHeader: string) => {
     const matchingHeaders: string[] = Object.keys(event?.headers ?? {}).filter(
@@ -16,5 +17,9 @@ export const getClientIpAddress = (event: APIGatewayProxyEvent) => {
     return getHeaderValue(event, "x-forwarded-for");
 };
 export const getSessionId = (event: APIGatewayProxyEvent) => {
-    return getHeaderValue(event, "session-id");
+    const sessionIdHeader = getHeaderValue(event, "session-id");
+    if (!sessionIdHeader) {
+        throw new InvalidRequestError("Invalid request: Missing session-id header");
+    }
+    return sessionIdHeader;
 };

--- a/lambdas/src/services/auth-request-validator.ts
+++ b/lambdas/src/services/auth-request-validator.ts
@@ -1,32 +1,30 @@
 import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda/trigger/api-gateway-proxy";
-import { ValidationResult } from "../types/validation-result";
+import { SessionValidationError } from "../types/errors";
 
 export class AuthorizationRequestValidator {
     validate(
         queryStringParams: APIGatewayProxyEventQueryStringParameters | null,
         sessionClientId: string,
         expectedRedirectUri: string,
-    ): ValidationResult {
+    ) {
         if (!queryStringParams) {
-            return { isValid: false, errorMsg: "Missing querystring parameters" };
+            throw new SessionValidationError("Session Validation Exception", "Missing querystring parameters");
         }
 
         const clientId = queryStringParams["client_id"];
         const redirectUri = queryStringParams["redirect_uri"];
         const responseType = queryStringParams["response_type"];
-        let errorMsg = null;
         if (!clientId) {
-            errorMsg = "Missing client_id parameter";
+            throw new SessionValidationError("Session Validation Exception", "Missing client_id parameter");
         } else if (!redirectUri) {
-            errorMsg = "Missing redirect_uri parameter";
+            throw new SessionValidationError("Session Validation Exception", "Missing redirect_uri parameter");
         } else if (!responseType) {
-            errorMsg = "Missing response_type parameter";
+            throw new SessionValidationError("Session Validation Exception", "Missing response_type parameter");
         } else if (clientId !== sessionClientId) {
-            errorMsg = "Invalid client_id parameter";
+            throw new SessionValidationError("Session Validation Exception", "Invalid client_id parameter");
         } else if (redirectUri !== expectedRedirectUri) {
-            errorMsg = "Invalid redirect_uri parameter";
+            throw new SessionValidationError("Session Validation Exception", "Invalid redirect_uri parameter");
         }
 
-        return { isValid: !errorMsg, errorMsg: errorMsg };
     }
 }

--- a/lambdas/src/types/errors.ts
+++ b/lambdas/src/types/errors.ts
@@ -1,9 +1,8 @@
 // Implementation of ErrorResponse.java in di-ipv-cri-lib
 export abstract class BaseError extends Error {
-    constructor(m: string, public statusCode?: number, public code?: number) {
-        super(m);
+    constructor(public readonly message: string, public statusCode?: number, public code?: number, public readonly details?: string) {
+        super(message);
     }
-
     getErrorSummary() {
         return this.code + ": " + this.message;
     }
@@ -18,21 +17,21 @@ export class InvalidAccessTokenError extends BaseError {
 }
 
 export class InvalidRequestError extends BaseError {
-    constructor(m: string) {
-        super(m);
+    constructor(public readonly message: string) {
+        super(message);
         this.statusCode = 400;
     }
 }
 
 export class InvalidPayloadError extends BaseError {
-    constructor(m: string) {
-        super(m);
+    constructor(public readonly message: string) {
+        super(message);
         this.statusCode = 400;
     }
 }
 
 export class ServerError extends BaseError {
-    constructor(m: string) {
+    constructor() {
         super("Server error");
         this.statusCode = 500;
     }
@@ -47,9 +46,22 @@ export class JwtSignatureValidationError extends BaseError {
 }
 
 export class SessionNotFoundError extends BaseError {
-    constructor(id: string) {
+    constructor(public readonly id: string) {
         super(`Could not find session item with id: ${id}`);
         this.statusCode = 400; // check
         this.code = 1029;
     }
 }
+
+export class SessionValidationError extends BaseError {
+
+    constructor(public readonly message: string, public readonly details?: string) {
+      super(message);
+      this.statusCode = 400;
+      this.code = 1019;
+      Object.setPrototypeOf(this, SessionValidationError.prototype);
+    }
+    getErrorSummary() {
+        return `${this.code}: ${this?.details}`;
+    }
+  }

--- a/lambdas/tests/unit/common/utils/request-utils.test.ts
+++ b/lambdas/tests/unit/common/utils/request-utils.test.ts
@@ -26,7 +26,7 @@ describe("request-utils", () => {
             expect(result).toBeUndefined;
         });
         test("returns undefined, if another header is present instead of x-forwarded-for", () => {
-            const result = getSessionId({
+            const result = getClientIpAddress({
                 headers: {
                     forwarded: "12345",
                 },
@@ -56,23 +56,22 @@ describe("request-utils", () => {
                 headers: {
                     "session-id": "12345",
                 },
-            } as any);
+            } as unknown as APIGatewayProxyEvent);
             expect(result).toBeUndefined;
         });
         test("returns undefined, if another header is present instead of session-id", () => {
-            const result = getSessionId({
+            expect(()=> getSessionId({
                 headers: {
                     session: "18345",
                 },
-            } as unknown as APIGatewayProxyEvent);
-            expect(result).toBeUndefined;
+            } as unknown as APIGatewayProxyEvent)).toThrow("Invalid request: Missing session-id header");
         });
     });
     describe("matching headers", () => {
         test("throws if there are multiple session-id headers", () => {
             jest.spyOn(global.Object, "keys").mockReturnValueOnce(["session-id", "session-id"]);
             const event = {
-                headers: {} as any,
+                headers: {} as unknown,
             } as unknown as APIGatewayProxyEvent;
             expect(() => getSessionId(event)).toThrow;
         });

--- a/lambdas/tests/unit/handlers/authorization-handler.test.ts
+++ b/lambdas/tests/unit/handlers/authorization-handler.test.ts
@@ -11,6 +11,8 @@ import {
     APIGatewayProxyEventQueryStringParameters,
 } from "aws-lambda/trigger/api-gateway-proxy";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { Metrics } from "@aws-lambda-powertools/metrics";
+import { InvalidRequestError, ServerError, SessionNotFoundError, SessionValidationError } from "../../../src/types/errors";
 
 jest.mock("../../../src/common/config/config-service");
 jest.mock("@aws-lambda-powertools/metrics");
@@ -42,14 +44,27 @@ describe("authorization-handler.ts", () => {
     });
 
     describe("Handler", () => {
+        let body = {};
+        let headers = {};
         let authorizationHandlerLambda: AuthorizationLambda;
         const configService = new ConfigService(jest.fn() as unknown as SSMClient);
         const sessionService = new SessionService(mockDynamoDbClient.prototype, configService);
         const authorizationRequestValidator = new AuthorizationRequestValidator();
         const mockConfigService = jest.mocked(ConfigService);
         const logger = jest.mocked(Logger);
+        const metrics = jest.mocked(Metrics);
 
         beforeEach(() => {
+            body = {
+                code: "",
+                grant_type: "authorization_code",
+                redirect_uri: "",
+                client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                client_assertion: "2",
+            };
+            headers = {
+                "session-id": "1",
+            } as APIGatewayProxyEventHeaders;
             jest.resetAllMocks();
             configService.init = () => Promise.resolve();
             authorizationHandlerLambda = new AuthorizationLambda(sessionService, authorizationRequestValidator);
@@ -71,230 +86,244 @@ describe("authorization-handler.ts", () => {
             const clientConfig = new Map<string, string>();
             clientConfig.set("code", "abc");
             clientConfig.set("redirectUri", "http://123.com");
-            jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
+            jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValueOnce(clientConfig);
         });
 
-        it("should fail when the response_type is missing", async () => {
-            const body = {
-                code: "",
-                grant_type: "authorization_code",
-                redirect_uri: "",
-                client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                client_assertion: "2",
-            };
 
-            const headers = {
-                "session-id": "1",
-            } as APIGatewayProxyEventHeaders;
-
-            const queryString = {
-                client_id: "1",
-                redirect_url: "http://123.com",
-            } as APIGatewayProxyEventQueryStringParameters;
-
-            const output = await authorizationHandlerLambda.handler(
-                {
-                    body: body,
-                    headers: headers,
-                    queryStringParameters: queryString,
-                } as unknown as APIGatewayProxyEvent,
-                null,
-            );
-
-            expect(output.statusCode).toBe(400);
-            expect(output.body).toContain("Session Validation Exception");
-        });
-
-        it("should fail when the redirect_uri is missing", async () => {
-            const body = {
-                code: "",
-                grant_type: "authorization_code",
-                redirect_uri: "",
-                client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                client_assertion: "2",
-            };
-
-            const headers = {
-                "session-id": "1",
-            } as APIGatewayProxyEventHeaders;
-
-            const queryString = {
-                client_id: "1",
-                response_type: "test",
-            } as APIGatewayProxyEventQueryStringParameters;
-
-            const output = await authorizationHandlerLambda.handler(
-                {
-                    body: body,
-                    headers: headers,
-                    queryStringParameters: queryString,
-                } as unknown as APIGatewayProxyEvent,
-                null,
-            );
-
-            expect(output.statusCode).toBe(400);
-            expect(output.body).toContain("Session Validation Exception");
-        });
-
-        it("should fail when the client_id is missing", async () => {
-            const body = {
-                code: "",
-                grant_type: "authorization_code",
-                redirect_uri: "",
-                client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                client_assertion: "2",
-            };
-
-            const headers = {
-                "session-id": "1",
-            } as APIGatewayProxyEventHeaders;
-
-            const queryString = {
-                redirect_uri: "http://123.com",
-                response_type: "test",
-            } as APIGatewayProxyEventQueryStringParameters;
-
-            const output = await authorizationHandlerLambda.handler(
-                {
-                    body: body,
-                    headers: headers,
-                    queryStringParameters: queryString,
-                } as unknown as APIGatewayProxyEvent,
-                null,
-            );
-
-            expect(output.statusCode).toBe(400);
-            expect(output.body).toContain("Session Validation Exception");
-        });
-
-        it("should pass with all queryStringParameters parameters populated", async () => {
-            const body = {
-                code: "",
-                grant_type: "authorization_code",
-                redirect_uri: "",
-                client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                client_assertion: "2",
-            };
-
-            const headers = {
-                "session-id": "1",
-            } as APIGatewayProxyEventHeaders;
-
-            const queryString = {
-                client_id: "1",
-                redirect_uri: "http://123.com",
-                response_type: "test",
-            } as APIGatewayProxyEventQueryStringParameters;
-
-            const output = await authorizationHandlerLambda.handler(
-                {
-                    body: body,
-                    headers: headers,
-                    queryStringParameters: queryString,
-                } as unknown as APIGatewayProxyEvent,
-                null,
-            );
-
-            expect(output.statusCode).toBe(200);
-            expect(output.body).not.toBeNull();
-        });
-
-        it("should should fail when there is no session-id", async () => {
-            const output = await authorizationHandlerLambda.handler(
-                {
-                    body: {
-                        code: "",
-                        grant_type: "authorization_code",
-                        redirect_uri: "",
-                        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        client_assertion: "2",
-                    },
-                } as unknown as APIGatewayProxyEvent,
-                null,
-            );
-            expect(output.statusCode).toBe(400);
-            expect(output.body).toContain("Invalid request: Missing session-id header");
-        });
-
-        it("should create an auth code if not available", async () => {
-            const body = {
-                code: "",
-                grant_type: "authorization_code",
-                redirect_uri: "",
-                client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                client_assertion: "2",
-            };
-            const headers = {
-                "session-id": "1",
-            } as APIGatewayProxyEventHeaders;
-
-            const queryString = {
-                client_id: "1",
-                redirect_uri: "http://123.com",
-                response_type: "test",
-            } as APIGatewayProxyEventQueryStringParameters;
-
-            const sessionItem: SessionItem = {
-                sessionId: "abc",
-                authorizationCodeExpiryDate: 1,
-                clientId: "1",
-                clientSessionId: "1",
-                redirectUri: "http://123.com",
-                accessToken: "",
-                accessTokenExpiryDate: 0,
-                authorizationCode: undefined,
-            };
-            jest.spyOn(sessionService, "getSession").mockReturnValue(
-                new Promise<any>((resolve) => {
-                    resolve(sessionItem);
-                }),
-            );
-            const createSpy = jest.spyOn(sessionService, "createAuthorizationCode");
-
-            await authorizationHandlerLambda.handler(
-                {
-                    body: body,
-                    headers: headers,
-                    queryStringParameters: queryString,
-                } as unknown as APIGatewayProxyEvent,
-                null,
-            )
-
-            expect(createSpy).toHaveBeenCalledWith(sessionItem);
-        });
-
-        it("should catch and return any errors", async () => {
-            jest.spyOn(logger.prototype, "appendKeys").mockImplementation(() => {
-                throw Error("Unable to perform task");
+        describe("has queryStringParameters parameters all populated", () => {
+            let queryString = {};
+            beforeEach(() => {
+                queryString = {
+                    client_id: "1",
+                    redirect_uri: "http://123.com",
+                    response_type: "test",
+                } as APIGatewayProxyEventQueryStringParameters;
+            })
+            it("should pass with 200 status code and return non empty body", async () => {
+                const metricsSpyAddMetrics = jest.spyOn(metrics.prototype, "addMetric");
+                const loggerSpyAppendkeys = jest.spyOn(logger.prototype, "appendKeys");
+                const loggerSpyInfo = jest.spyOn(logger.prototype, "info");
+    
+                const output = await authorizationHandlerLambda.handler(
+                    {
+                        body,
+                        headers,
+                        queryStringParameters: queryString,
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+    
+                expect(output.statusCode).toBe(200);
+                expect(output.body).not.toBeNull();
+                expect(loggerSpyInfo).toBeCalledWith("found session");
+                expect(loggerSpyAppendkeys).toBeCalledWith({ govuk_signin_journey_id: "1" });
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 1);
             });
-            const errorSpy = jest.spyOn(logger.prototype, "error");
-
-            const output = await authorizationHandlerLambda.handler(
-                {
-                    body: {
-                        code: "",
-                        grant_type: "authorization_code",
-                        redirect_uri: "",
-                        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        client_assertion: "2",
-                    },
-                    headers: {
-                        "session-id": "1",
-                    },
-                    queryStringParameters: {
-                        client_id: "1",
-                        redirect_uri: "http://123.com",
-                        response_type: "test",
-                    }
-                } as unknown as APIGatewayProxyEvent,
-                null,
-            );
-
-            expect(output).toEqual({
-                statusCode: 500,
-                body: "An error has occurred: Error: Unable to perform task"
+    
+            it("should pass with log message and metrics sent", async () => {
+                const metricsSpyAddMetrics = jest.spyOn(metrics.prototype, "addMetric");
+                const loggerSpyAppendkeys = jest.spyOn(logger.prototype, "appendKeys");
+                const loggerSpyInfo = jest.spyOn(logger.prototype, "info");
+    
+                await authorizationHandlerLambda.handler(
+                    {
+                        body,
+                        headers,
+                        queryStringParameters: queryString,
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+    
+                expect(loggerSpyInfo).toBeCalledWith("found session");
+                expect(loggerSpyAppendkeys).toBeCalledWith({ govuk_signin_journey_id: "1" });
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 1);
             });
-            expect(errorSpy).toHaveBeenCalledWith("authorization lambda error occurred", Error("Unable to perform task"))
+    
+            it("should create an auth code if not available", async () => {
+                const sessionItem: SessionItem = {
+                    sessionId: "abc",
+                    authorizationCodeExpiryDate: 1,
+                    clientId: "1",
+                    clientSessionId: "1",
+                    redirectUri: "http://123.com",
+                    accessToken: "",
+                    accessTokenExpiryDate: 0,
+                    authorizationCode: undefined,
+                };
+                jest.spyOn(sessionService, "getSession").mockReturnValue(
+                    new Promise<any>((resolve) => {
+                        resolve(sessionItem);
+                    }),
+                );
+                const createSpy = jest.spyOn(sessionService, "createAuthorizationCode");
+    
+                await authorizationHandlerLambda.handler(
+                    {
+                        body,
+                        headers,
+                        queryStringParameters: queryString,
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+                expect(createSpy).toHaveBeenCalledWith(sessionItem);
+            });
         });
+
+
+        describe("authorization request has missing attributes", () => {
+            let metricsSpyAddMetrics: jest.SpyInstance;
+            let loggerSpyError: jest.SpyInstance;
+            beforeEach(() => {
+                metricsSpyAddMetrics = jest.spyOn(metrics.prototype, "addMetric");
+                loggerSpyError = jest.spyOn(logger.prototype, "error");
+            });
+            it("should fail validation when response_type is missing from queryString", async () => {
+                const queryString = {
+                    client_id: "1",
+                    redirect_uri: "http://123.com",
+                } as APIGatewayProxyEventQueryStringParameters;
+
+                const output = await authorizationHandlerLambda.handler(
+                    {
+                        body: body,
+                        headers: headers,
+                        queryStringParameters: queryString,
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+
+                expect(output.statusCode).toBe(400);
+                expect(output.body).toContain("Session Validation Exception");
+                expect(output.body).toContain("Missing response_type parameter");
+
+                expect(loggerSpyError).toBeCalledWith(
+                    "authorization lambda error occurred",
+                    expect.any(SessionValidationError),
+                );
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 0);
+            });
+            it("should fail validation when the redirect_uri is missing from from queryString", async () => {
+                const queryString = {
+                    client_id: "1",
+                    response_type: "test",
+                } as APIGatewayProxyEventQueryStringParameters;
+
+                const output = await authorizationHandlerLambda.handler(
+                    {
+                        body: body,
+                        headers: headers,
+                        queryStringParameters: queryString,
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+
+                expect(output.statusCode).toBe(400);
+                expect(output.body).toContain("Session Validation Exception");
+                expect(output.body).toContain("Missing redirect_uri parameter");
+
+                expect(loggerSpyError).toBeCalledWith(
+                    "authorization lambda error occurred",
+                    expect.any(SessionValidationError),
+                );
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 0);
+            });
+            it("should fail validation should fail when the client_id is missing", async () => {
+
+                const queryString = {
+                    redirect_uri: "http://123.com",
+                    response_type: "test",
+                } as APIGatewayProxyEventQueryStringParameters;
+
+                const output = await authorizationHandlerLambda.handler(
+                    {
+                        body: body,
+                        headers: headers,
+                        queryStringParameters: queryString,
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+
+                expect(output.statusCode).toBe(400);
+                expect(output.body).toContain("Session Validation Exception");
+                expect(output.body).toContain("Missing client_id parameter");
+
+                expect(loggerSpyError).toBeCalledWith(
+                    "authorization lambda error occurred",
+                    expect.any(SessionValidationError),
+                );
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 0);
+            });
+        });
+
+        describe("has session present", () => {
+            it("should should fail when there is no session-id in the authorization request header", async () => {
+                const metricsSpyAddMetrics = jest.spyOn(metrics.prototype, "addMetric");
+                const loggerSpyError = jest.spyOn(logger.prototype, "error");
+                const output = await authorizationHandlerLambda.handler(
+                    {
+                        body,
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+                expect(output.statusCode).toBe(400);
+                expect(output.body).toContain("Invalid request: Missing session-id header");
+                expect(loggerSpyError).toBeCalledWith(
+                    "authorization lambda error occurred",
+                    expect.any(InvalidRequestError),
+                );
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 0);
+            });
+            it("should should fail when no existing session is found for the current request", async () => {
+                const metricsSpyAddMetrics = jest.spyOn(metrics.prototype, "addMetric");
+                const loggerSpyError = jest.spyOn(logger.prototype, "error");
+                const sessionId = "1";
+                const sessionNotFound = new SessionNotFoundError(sessionId);
+
+                jest.spyOn(sessionService, "getSession").mockRejectedValueOnce(sessionNotFound)
+
+                authorizationHandlerLambda = new AuthorizationLambda(sessionService, authorizationRequestValidator);
+
+                const output = await authorizationHandlerLambda.handler(
+                    {
+                        body,
+                        headers
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+                expect(output.statusCode).toBe(400);
+                expect(output.body).toContain(`Could not find session item with id: ${sessionId}`);
+                expect(loggerSpyError).toBeCalledWith(
+                    "authorization lambda error occurred",
+                    sessionNotFound,
+                );
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 0);
+            });
+
+
+            it("should should fail when a server error occurs", async () => {
+                const metricsSpyAddMetrics = jest.spyOn(metrics.prototype, "addMetric");
+                const loggerSpyError = jest.spyOn(logger.prototype, "error");
+                const serverError = new ServerError();
+
+                jest.spyOn(sessionService, "getSession").mockRejectedValueOnce(serverError)
+
+                authorizationHandlerLambda = new AuthorizationLambda(sessionService, authorizationRequestValidator);
+
+                const output = await authorizationHandlerLambda.handler(
+                    {
+                        body,
+                        headers
+                    } as unknown as APIGatewayProxyEvent,
+                    null,
+                );
+                expect(output.statusCode).toBe(500);
+                expect(output.body).toContain("undefined: Server error");
+                expect(loggerSpyError).toBeCalledWith(
+                    "authorization lambda error occurred",
+                    serverError,
+                );
+                expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 0);
+            });
+        })
     });
 });

--- a/lambdas/tests/unit/services/auth-request-validator.test.ts
+++ b/lambdas/tests/unit/services/auth-request-validator.test.ts
@@ -1,4 +1,6 @@
+import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda";
 import { AuthorizationRequestValidator } from "../../../src/services/auth-request-validator";
+import { SessionValidationError } from "../../../src/types/errors";
 
 describe("auth-request-validator", () => {
     describe("validate", () => {
@@ -10,15 +12,17 @@ describe("auth-request-validator", () => {
         });
         describe("no queryStringParams", () => {
             it("should return missing querystring parameters", () => {
-                const validationResult = authRequestValidator.validate(null, existingClientId, configuredRedirectUri);
-                expect(validationResult).toEqual({
-                    isValid: false,
-                    errorMsg: "Missing querystring parameters",
-                });
+                const sessionValidationError = new SessionValidationError("Session Validation Exception", "Missing querystring parameters");
+                expect(() => authRequestValidator.validate(
+                    null,
+                    existingClientId,
+                    configuredRedirectUri,
+                )).toThrow("Session Validation Exception");
+                expect(sessionValidationError.details).toBe("Missing querystring parameters");
             });
         });
         describe("well-formed queryStringParams", () => {
-            let queryStringParams: any;
+            let queryStringParams: APIGatewayProxyEventQueryStringParameters;
             beforeEach(() => {
                 queryStringParams = {
                     client_id: "a-valid-clientId",
@@ -29,109 +33,96 @@ describe("auth-request-validator", () => {
 
             describe("with an existing client id and the configured redirect_uri", () => {
                 it("should return object true isValid attribute and null errorMsg", () => {
-                    const validationResult = authRequestValidator.validate(
+                    expect(() => authRequestValidator.validate(
                         queryStringParams,
                         existingClientId,
                         configuredRedirectUri,
-                    );
-                    expect(validationResult).toEqual({
-                        isValid: true,
-                        errorMsg: null,
-                    });
+                    )).not.toThrow();
+
                 });
             });
             describe("with a mismatched client id", () => {
                 it("should return invalid client id parameter error", () => {
                     queryStringParams["client_id"] = "an-unexpected-clientId-in-the-request";
+                    const sessionValidationError = new SessionValidationError("Session Validation Exception", "Missing client_id parameter");
 
-                    const validationResult = authRequestValidator.validate(
+                    expect(() => authRequestValidator.validate(
                         queryStringParams,
                         existingClientId,
                         configuredRedirectUri,
-                    );
-                    expect(validationResult).toEqual({
-                        isValid: false,
-                        errorMsg: "Invalid client_id parameter",
-                    });
+                    )).toThrow("Session Validation Exception");
+                    expect(sessionValidationError.details).toBe("Missing client_id parameter");
                 });
             });
             describe("with mismatching configured redirect_uri", () => {
                 it("should return invalid redirect uri parameter error", () => {
                     queryStringParams["redirect_uri"] = "an-unexpected-redirect-uri-in-the-request";
+                    const sessionValidationError = new SessionValidationError("Session Validation Exception", "Invalid redirect_uri parameter");
 
-                    const validationResult = authRequestValidator.validate(
+                    expect(() => authRequestValidator.validate(
                         queryStringParams,
                         existingClientId,
                         configuredRedirectUri,
-                    );
-                    expect(validationResult).toEqual({
-                        isValid: false,
-                        errorMsg: "Invalid redirect_uri parameter",
-                    });
+                    )).toThrow("Session Validation Exception");
+                    expect(sessionValidationError.details).toBe("Invalid redirect_uri parameter")
                 });
             });
             describe("client id and redirect_uri not matching", () => {
                 it("first invalid returned i.e. client_id uri parameter error", () => {
                     queryStringParams["client_id"] = "an-unexpected-redirect-uri-in-the-request";
                     queryStringParams["redirect_uri"] = "an-unexpected-redirect-uri-in-the-request";
+                    const sessionValidationError = new SessionValidationError("Session Validation Exception", "Invalid client_id parameter");
 
-                    const validationResult = authRequestValidator.validate(
+                    expect(() => authRequestValidator.validate(
                         queryStringParams,
                         existingClientId,
                         configuredRedirectUri,
-                    );
-                    expect(validationResult).toEqual({
-                        isValid: false,
-                        errorMsg: "Invalid client_id parameter",
-                    });
+                    )).toThrow("Session Validation Exception");
+                    expect(sessionValidationError.details).toBe("Invalid client_id parameter");
                 });
             });
         });
         describe("incomplete queryStringParam", () => {
             describe("missing param attributes", () => {
-                let queryStringParams: any;
+                let queryStringParams: APIGatewayProxyEventQueryStringParameters;
                 beforeEach(() => {
                     queryStringParams = {};
                 });
                 it("should return missing client id parameter error", () => {
                     (queryStringParams["redirect_uri"] = "a-valid-redirect-uri"),
                         (queryStringParams["response_type"] = "a-valid-response-type");
+                    const sessionValidationError = new SessionValidationError("Session Validation Exception", "Missing client_id parameter");
 
-                    const validationResult = authRequestValidator.validate(
+                    expect(() => authRequestValidator.validate(
                         queryStringParams,
                         existingClientId,
                         configuredRedirectUri,
-                    );
-                    expect(validationResult).toEqual({
-                        isValid: false,
-                        errorMsg: "Missing client_id parameter",
-                    });
+                    )).toThrow("Session Validation Exception");
+                    expect(sessionValidationError.details).toBe("Missing client_id parameter");
                 });
                 it("should return missing redirect uri parameter error", () => {
                     queryStringParams["client_id"] = "a-valid-clientId";
                     queryStringParams["response_type"] = "a-valid-response-type";
-                    const validationResult = authRequestValidator.validate(
+                    const sessionValidationError = new SessionValidationError("Session Validation Exception", "Missing redirect_uri parameter");
+
+                    expect(() => authRequestValidator.validate(
                         queryStringParams,
                         existingClientId,
                         configuredRedirectUri,
-                    );
-                    expect(validationResult).toEqual({
-                        isValid: false,
-                        errorMsg: "Missing redirect_uri parameter",
-                    });
+                    )).toThrow("Session Validation Exception");
+                    expect(sessionValidationError.details).toBe("Missing redirect_uri parameter");
                 });
                 it("should return missing response type parameter error", () => {
                     queryStringParams["client_id"] = "a-valid-clientId";
                     queryStringParams["redirect_uri"] = "a-valid-redirect-uri";
-                    const validationResult = authRequestValidator.validate(
-                        queryStringParams,
+                    const sessionValidationError = new SessionValidationError("Session Validation Exception", "Missing response_type parameter");
+
+                    expect(() => authRequestValidator.validate(queryStringParams,
                         existingClientId,
                         configuredRedirectUri,
-                    );
-                    expect(validationResult).toEqual({
-                        isValid: false,
-                        errorMsg: "Missing response_type parameter",
-                    });
+                    )).toThrow("Session Validation Exception");
+                    
+                    expect(sessionValidationError.details).toBe("Missing response_type parameter");
                 });
             });
         });


### PR DESCRIPTION
## Proposed changes

Instead of using generic Error this PR ensures the specification of a defined error type
the mirrors the java one see https://github.com/alphagov/di-ipv-cri-lib/blob/806c02d8beda586f301030b85b3a0d070a64bfd0/src/main/java/uk/gov/di/ipv/cri/common/library/error/ErrorResponse.java#L22
Instead of returning a ValidationResult and then inspecting it for which error to handle
throw the expected error and allow this to be handled by the catch block in the handler.
This aligns with pattern used in the access-token-handler

### What changed

Stopped using ValidationResult, throw specific error

### Why did it change

To ensure we handle errors, in a similar approach.

### Issue tracking

- [OJ-1231](https://govukverify.atlassian.net/browse/OJ-1231))


[OJ-1231]: https://govukverify.atlassian.net/browse/OJ-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ