### PR TITLE
fix: Pin gradle to 7.4.2 for post merge matrix workflow

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -49,6 +49,11 @@ jobs:
           java-version: 11
           distribution: zulu
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.4.2
+
       - name: Setup SAM
         uses: aws-actions/setup-sam@v2
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -188,70 +188,70 @@
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d9c4666052c745e7c6f573d794aca9a4a6f3be8e",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 102
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 103
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 107
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 110
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 111
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "a526684ba66fb0f1d7c1bd531c70f1bf14db6a6a",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 114
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0aa77508d48646456f474415968125a444b86312",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 115
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0ec0ad1e2eb3fcd03bcd813c6ade3927eb58c621",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 118
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f5f97a4d43698c40eb4eb208e2df8cd688479904",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 119
       }
     ],
     ".github/workflows/pre-merge-integration-test.yml": [
@@ -335,5 +335,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-26T16:55:34Z"
+  "generated_at": "2023-02-20T12:25:30Z"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Pin `sam build` to Gradle 7.4.2 as using features not supported by Gradle 8

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks