### PR TITLE
OJ-1256: throw specific sessionValidationerr

### DIFF
--- a/lambdas/src/handlers/authorization-handler.ts
+++ b/lambdas/src/handlers/authorization-handler.ts
@@ -45,7 +45,7 @@ export class AuthorizationLambda implements LambdaInterface {
             this.authorizationRequestValidator.validate(
                 event.queryStringParameters,
                 sessionItem.clientId,
-                clientConfig!.get(ClientConfigKey.JWT_REDIRECT_URI)!,
+                clientConfig?.get(ClientConfigKey.JWT_REDIRECT_URI) as string,
             );
 
             logger.appendKeys({ govuk_signin_journey_id: sessionItem.clientSessionId });

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -53,55 +53,29 @@ export class SessionLambda implements LambdaInterface {
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
     public async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
         try {
-            await configInitPromise;
-            const deserialisedRequestBody = JSON.parse(event.body!);
+            const deserialisedRequestBody = JSON.parse(event.body as string);
             const requestBodyClientId = deserialisedRequestBody.client_id;
-            let decryptedJwt = null;
-            try {
-                decryptedJwt = await this.jweDecrypter.decryptJwe(deserialisedRequestBody.request);
-            } catch (e) {
-                logger.error("Invalid request - JWE decryption failed", e as Error);
-                return {
-                    statusCode: 400,
-                    body: "Invalid request: JWE decryption failed",
-                };
-            }
+            const clientIpAddress = getClientIpAddress(event);
 
+            await configInitPromise;
             if (!configService.hasClientConfig(requestBodyClientId)) {
                 await this.initClientConfig(requestBodyClientId);
             }
-            const criClientConfig = configService.getClientConfig(requestBodyClientId)!;
 
+            const criClientConfig = configService.getClientConfig(requestBodyClientId) as Map<string, string>;
             const sessionRequestValidator = this.sessionRequestValidatorFactory.create(criClientConfig);
-            const jwtValidationResult = await sessionRequestValidator.validateJwt(decryptedJwt, requestBodyClientId);
-            if (!jwtValidationResult.isValid) {
-                return {
-                    statusCode: 400,
-                    body: `Invalid request: JWT validation/verification failed: ${jwtValidationResult.errorMsg}`,
-                };
-            }
 
-            const jwtPayload = jwtValidationResult.validatedObject;
-            const clientIpAddress = getClientIpAddress(event);
-
-            metrics.addDimension("issuer", requestBodyClientId);
-
+            const decryptedJwt = await this.jweDecrypter.decryptJwe(deserialisedRequestBody.request);
+            const jwtPayload = await sessionRequestValidator.validateJwt(decryptedJwt, requestBodyClientId);
             const sessionRequestSummary = this.createSessionRequestSummary(jwtPayload, clientIpAddress);
             const sessionId: string = await this.sessionService.saveSession(sessionRequestSummary);
+            await this.personIdentityService.savePersonIdentity(jwtPayload.shared_claims as PersonIdentity, sessionId);
+            await this.sendAuditEvent(sessionId, sessionRequestSummary, clientIpAddress);
 
+            metrics.addDimension("issuer", requestBodyClientId);
+            metrics.addMetric(SESSION_CREATED_METRIC, MetricUnits.Count, 1);
             logger.appendKeys({ govuk_signin_journey_id: sessionId });
             logger.info("created session");
-
-            if (jwtPayload.shared_claims) {
-                await this.personIdentityService.savePersonIdentity(
-                    jwtPayload.shared_claims as PersonIdentity,
-                    sessionId,
-                );
-            }
-
-            metrics.addMetric(SESSION_CREATED_METRIC, MetricUnits.Count, 1);
-
-            await this.sendAuditEvent(sessionId, sessionRequestSummary, clientIpAddress);
 
             return {
                 statusCode: 201,
@@ -111,12 +85,16 @@ export class SessionLambda implements LambdaInterface {
                     redirect_uri: jwtPayload.redirect_uri,
                 }),
             };
-        } catch (err) {
+        } catch (err: any) {
             logger.error("session lambda error occurred", err as Error);
             metrics.addMetric(SESSION_CREATED_METRIC, MetricUnits.Count, 0);
             return {
-                statusCode: 500,
-                body: `An error has occurred: ${JSON.stringify(err) == "{}" ? err : JSON.stringify(err)}`,
+                statusCode: err?.statusCode ?? 500,
+                body: JSON.stringify({
+                    message: err?.statusCode >= 500 ? "Server Error" : err.message,
+                    code: err?.code,
+                    errorSummary: err?.getErrorSummary(),
+                }),
             };
         }
     }
@@ -135,7 +113,7 @@ export class SessionLambda implements LambdaInterface {
     ): SessionRequestSummary {
         return {
             clientId: jwtPayload["client_id"] as string,
-            clientIpAddress: clientIpAddress ?? null,
+            clientIpAddress: clientIpAddress as string,
             clientSessionId: jwtPayload["govuk_signin_journey_id"] as string,
             persistentSessionId: jwtPayload["persistent_session_id"] as string,
             redirectUri: jwtPayload["redirect_uri"] as string,

--- a/lambdas/src/services/session-service.ts
+++ b/lambdas/src/services/session-service.ts
@@ -92,7 +92,7 @@ export class SessionService {
             },
         });
         await this.dynamoDbClient.send(putSessionCommand);
-        return putSessionCommand.input.Item!.sessionId;
+        return putSessionCommand?.input?.Item?.sessionId;
     }
 
     private getSessionTableName(): string {

--- a/lambdas/src/types/errors.ts
+++ b/lambdas/src/types/errors.ts
@@ -42,6 +42,26 @@ export class ServerError extends BaseError {
     }
 }
 
+export class JweDecrypterError extends BaseError {
+    constructor(public readonly err: Error) {
+        super(`Session Validation Error", "Invalid request - JWE decryption failed :${err}`);
+        this.statusCode = 403;
+        Object.setPrototypeOf(this, JweDecrypterError.prototype);
+    }
+}
+
+export class GenericServerError extends BaseError {
+    constructor(public readonly details?: string) {
+        super("Request failed due to a server error");
+        this.statusCode = 500;
+        this.code = 1025;
+        Object.setPrototypeOf(this, GenericServerError.prototype);
+    }
+    getErrorSummary() {
+        return `${this.code}: ${this?.message}`;
+    }
+}
+
 export class JwtSignatureValidationError extends BaseError {
     constructor() {
         super("Signature of the shared attribute JWT is invalid");

--- a/lambdas/src/types/validation-result.ts
+++ b/lambdas/src/types/validation-result.ts
@@ -1,5 +1,0 @@
-export interface ValidationResult {
-    isValid: boolean;
-    errorMsg: string | null;
-    validatedObject?: any;
-}


### PR DESCRIPTION
## Proposed changes

Throw specific errors instead of returning a generic error result object, 
now error handling is done in manner consistent with the other handlers

### What changed

Error handling in SessionHandler, aligned with the other handler

<!-- Describe the changes in detail - the "what"-->

### Why did it change

To allow a consist way of handling errors

- [OJ-1256](https://govukverify.atlassian.net/browse/OJ-1256)

[OJ-1256]: https://govukverify.atlassian.net/browse/OJ-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ