### PR TITLE
OJ-1256: replace try catch style assertions in auth-request-validator test

### DIFF
--- a/lambdas/tests/unit/services/auth-request-validator.test.ts
+++ b/lambdas/tests/unit/services/auth-request-validator.test.ts
@@ -1,6 +1,5 @@
 import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda";
 import { AuthorizationRequestValidator } from "../../../src/services/auth-request-validator";
-import { SessionValidationError } from "../../../src/types/errors";
 
 describe("auth-request-validator", () => {
     describe("validate", () => {
@@ -12,12 +11,12 @@ describe("auth-request-validator", () => {
         });
         describe("no queryStringParams", () => {
             it("should return missing querystring parameters", () => {
-                try {
-                    authRequestValidator.validate(null, existingClientId, configuredRedirectUri);
-                } catch (error) {
-                    expect((error as SessionValidationError).details).toBe("Missing querystring parameters");
-                    expect((error as SessionValidationError).message).toBe("Session Validation Exception");
-                }
+                expect(() => authRequestValidator.validate(null, existingClientId, configuredRedirectUri)).toThrow(
+                    expect.objectContaining({
+                        details: "Missing querystring parameters",
+                        message: "Session Validation Exception",
+                    }),
+                );
             });
         });
         describe("well-formed queryStringParams", () => {
@@ -40,35 +39,41 @@ describe("auth-request-validator", () => {
             describe("with a mismatched client id", () => {
                 it("should return invalid client id parameter error", () => {
                     queryStringParams["client_id"] = "an-unexpected-clientId-in-the-request";
-                    try {
-                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
-                    } catch (error) {
-                        expect((error as SessionValidationError).details).toBe("Invalid client_id parameter");
-                        expect((error as SessionValidationError).message).toBe("Session Validation Exception");
-                    }
+                    expect(() =>
+                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri),
+                    ).toThrow(
+                        expect.objectContaining({
+                            details: "Invalid client_id parameter",
+                            message: "Session Validation Exception",
+                        }),
+                    );
                 });
             });
             describe("with mismatching configured redirect_uri", () => {
                 it("should return invalid redirect uri parameter error", () => {
                     queryStringParams["redirect_uri"] = "an-unexpected-redirect-uri-in-the-request";
-                    try {
-                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
-                    } catch (error) {
-                        expect((error as SessionValidationError).details).toBe("Invalid redirect_uri parameter");
-                        expect((error as SessionValidationError).message).toBe("Session Validation Exception");
-                    }
+                    expect(() =>
+                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri),
+                    ).toThrow(
+                        expect.objectContaining({
+                            details: "Invalid redirect_uri parameter",
+                            message: "Session Validation Exception",
+                        }),
+                    );
                 });
             });
             describe("client id and redirect_uri not matching", () => {
                 it("first invalid returned i.e. client_id uri parameter error", () => {
                     queryStringParams["client_id"] = "an-unexpected-redirect-uri-in-the-request";
                     queryStringParams["redirect_uri"] = "an-unexpected-redirect-uri-in-the-request";
-                    try {
-                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
-                    } catch (error) {
-                        expect((error as SessionValidationError).details).toBe("Invalid client_id parameter");
-                        expect((error as SessionValidationError).message).toBe("Session Validation Exception");
-                    }
+                    expect(() =>
+                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri),
+                    ).toThrow(
+                        expect.objectContaining({
+                            details: "Invalid client_id parameter",
+                            message: "Session Validation Exception",
+                        }),
+                    );
                 });
             });
         });
@@ -81,32 +86,40 @@ describe("auth-request-validator", () => {
                 it("should return missing client id parameter error", () => {
                     (queryStringParams["redirect_uri"] = "a-valid-redirect-uri"),
                         (queryStringParams["response_type"] = "a-valid-response-type");
-                    try {
-                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
-                    } catch (error) {
-                        expect((error as SessionValidationError).details).toBe("Missing client_id parameter");
-                        expect((error as SessionValidationError).message).toBe("Session Validation Exception");
-                    }
+                    expect(() =>
+                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri),
+                    ).toThrow(
+                        expect.objectContaining({
+                            details: "Missing client_id parameter",
+                            message: "Session Validation Exception",
+                        }),
+                    );
                 });
                 it("should return missing redirect uri parameter error", () => {
                     queryStringParams["client_id"] = "a-valid-clientId";
                     queryStringParams["response_type"] = "a-valid-response-type";
-                    try {
-                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
-                    } catch (error) {
-                        expect((error as SessionValidationError).details).toBe("Missing redirect_uri parameter");
-                        expect((error as SessionValidationError).message).toBe("Session Validation Exception");
-                    }
+
+                    expect(() =>
+                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri),
+                    ).toThrow(
+                        expect.objectContaining({
+                            details: "Missing redirect_uri parameter",
+                            message: "Session Validation Exception",
+                        }),
+                    );
                 });
                 it("should return missing response type parameter error", () => {
                     queryStringParams["client_id"] = "a-valid-clientId";
                     queryStringParams["redirect_uri"] = "a-valid-redirect-uri";
-                    try {
-                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri);
-                    } catch (error) {
-                        expect((error as SessionValidationError).details).toBe("Missing response_type parameter");
-                        expect((error as SessionValidationError).message).toBe("Session Validation Exception");
-                    }
+
+                    expect(() =>
+                        authRequestValidator.validate(queryStringParams, existingClientId, configuredRedirectUri),
+                    ).toThrow(
+                        expect.objectContaining({
+                            details: "Missing response_type parameter",
+                            message: "Session Validation Exception",
+                        }),
+                    );
                 });
             });
         });


### PR DESCRIPTION
## Proposed changes

Change assertion style

### What changed

Change assertion style from try-catch to expect-throw

### Why did it change

Recommended improvement
