### PR TITLE
Oj-1270: fix eslint no unused vars

### DIFF
--- a/lambdas/.eslintrc.js
+++ b/lambdas/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
     rules: {
         "no-console": 2,
         "padding-line-between-statements": ["error", { blankLine: "any", prev: "*", next: "*" }],
+        '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_', "argsIgnorePattern": "^_" }],
     },
 };

--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -29,7 +29,7 @@ export class AccessTokenLambda implements LambdaInterface {
 
     @logger.injectLambdaContext({ clearState: true })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
-    public async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
+    public async handler(event: APIGatewayProxyEvent, _context: any): Promise<APIGatewayProxyResult> {
         try {
             await initPromise;
 

--- a/lambdas/src/handlers/authorization-handler.ts
+++ b/lambdas/src/handlers/authorization-handler.ts
@@ -16,7 +16,7 @@ const dynamoDbClient = createClient(AwsClientType.DYNAMO) as DynamoDBDocument;
 const ssmClient = createClient(AwsClientType.SSM) as SSMClient;
 const logger = new Logger();
 const metrics = new Metrics();
-const tracer = new Tracer({ captureHTTPsRequests: false });
+const _tracer = new Tracer({ captureHTTPsRequests: false });
 const configService = new ConfigService(ssmClient);
 const initPromise = configService.init([CommonConfigKey.SESSION_TABLE_NAME]);
 const AUTHORIZATION_SENT_METRIC = "authorization_sent";
@@ -29,8 +29,8 @@ export class AuthorizationLambda implements LambdaInterface {
 
     @logger.injectLambdaContext({ clearState: true })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
-    @tracer.captureLambdaHandler({ captureResponse: false })
-    public async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
+    @_tracer.captureLambdaHandler({ captureResponse: false })
+    public async handler(event: APIGatewayProxyEvent, _context: any): Promise<APIGatewayProxyResult> {
         try {
             await initPromise;
 

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -28,7 +28,7 @@ const kmsClient = createClient(AwsClientType.KMS) as KMSClient;
 
 const logger = new Logger();
 const metrics = new Metrics();
-const tracer = new Tracer({ captureHTTPsRequests: false });
+const _tracer = new Tracer({ captureHTTPsRequests: false });
 const configService = new ConfigService(ssmClient);
 const configInitPromise = configService.init([
     CommonConfigKey.SESSION_TABLE_NAME,
@@ -48,10 +48,10 @@ export class SessionLambda implements LambdaInterface {
         private readonly auditService: AuditService,
     ) {}
 
-    @tracer.captureLambdaHandler({ captureResponse: false })
+    @_tracer.captureLambdaHandler({ captureResponse: false })
     @logger.injectLambdaContext({ clearState: true })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
-    public async handler(event: APIGatewayProxyEvent, context: any): Promise<APIGatewayProxyResult> {
+    public async handler(event: APIGatewayProxyEvent, _context: any): Promise<APIGatewayProxyResult> {
         try {
             const deserialisedRequestBody = JSON.parse(event.body as string);
             const requestBodyClientId = deserialisedRequestBody.client_id;

--- a/lambdas/tests/unit/common/config/config-service.test.ts
+++ b/lambdas/tests/unit/common/config/config-service.test.ts
@@ -3,7 +3,7 @@ import { ClientConfigKey, CommonConfigKey } from "../../../../src/types/config-k
 import { ConfigService } from "../../../../src/common/config/config-service";
 
 const getMockSend = (key: CommonConfigKey, value?: string) => {
-    const mockPromise = new Promise<any>((resolve, reject) => {
+    const mockPromise = new Promise<any>((resolve) => {
         resolve({
             Parameters: [
                 {
@@ -68,7 +68,7 @@ describe("ConfigService", () => {
         });
 
         it("should throw an error for an invalid client ID", async () => {
-            const mockPromise = new Promise<any>((resolve, reject) => {
+            const mockPromise = new Promise<any>((resolve) => {
                 resolve({
                     Parameters: [],
                 });
@@ -86,7 +86,7 @@ describe("ConfigService", () => {
         });
 
         it("should throw an error for invalid parameters", async () => {
-            const mockPromise = new Promise<any>((resolve, reject) => {
+            const mockPromise = new Promise<any>((resolve) => {
                 resolve({
                     Parameters: [],
                     InvalidParameters: ["invalid-param"],

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -369,7 +369,6 @@ describe("access-token-handler.ts", () => {
             it("should fail when dynamoDb is not available", async () => {
                 const redirectUri = "http://123.abc.com";
                 const code = "123abc";
-                const clientSessionId = "1";
 
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
@@ -386,17 +385,6 @@ describe("access-token-handler.ts", () => {
                 clientConfig.set("code", code);
                 clientConfig.set("redirectUri", redirectUri);
                 jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
-                const sessionItem: SessionItem = {
-                    sessionId: code,
-                    authorizationCodeExpiryDate: 1,
-                    clientId: "1",
-                    clientSessionId: clientSessionId,
-                    redirectUri: redirectUri,
-                    accessToken: "",
-                    accessTokenExpiryDate: 0,
-                    authorizationCode: code,
-                };
 
                 const event = {
                     body: {

--- a/lambdas/tests/unit/handlers/authorization-handler.test.ts
+++ b/lambdas/tests/unit/handlers/authorization-handler.test.ts
@@ -13,7 +13,6 @@ import {
 import { Logger } from "@aws-lambda-powertools/logger";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import {
-    BaseError,
     InvalidRequestError,
     ServerError,
     SessionNotFoundError,


### PR DESCRIPTION
## Proposed changes

To fix eslint no unsed vars some exemptions need to be made

### What changed

Handlers require a second parameter; context, this is often unused 
by prefixing with _ i.e using `_context` exempts it from this eslint rule 
Also @decorator ie. `tracer` is just applied on some handlers but 
is not referred to, these are also exempt 

### Why did it change

Addressing eslint warnings

- [Oj-1270](https://govukverify.atlassian.net/browse/Oj-1270)
