### PR TITLE
OJ-1270: fix eslint no implicit any part-1

### DIFF
--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -29,7 +29,7 @@ export class AccessTokenLambda implements LambdaInterface {
 
     @logger.injectLambdaContext({ clearState: true })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
-    public async handler(event: APIGatewayProxyEvent, _context: any): Promise<APIGatewayProxyResult> {
+    public async handler(event: APIGatewayProxyEvent, _context: unknown): Promise<APIGatewayProxyResult> {
         try {
             await initPromise;
 

--- a/lambdas/src/handlers/authorization-handler.ts
+++ b/lambdas/src/handlers/authorization-handler.ts
@@ -30,7 +30,7 @@ export class AuthorizationLambda implements LambdaInterface {
     @logger.injectLambdaContext({ clearState: true })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
     @_tracer.captureLambdaHandler({ captureResponse: false })
-    public async handler(event: APIGatewayProxyEvent, _context: any): Promise<APIGatewayProxyResult> {
+    public async handler(event: APIGatewayProxyEvent, _context: unknown): Promise<APIGatewayProxyResult> {
         try {
             await initPromise;
 

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -51,7 +51,7 @@ export class SessionLambda implements LambdaInterface {
     @_tracer.captureLambdaHandler({ captureResponse: false })
     @logger.injectLambdaContext({ clearState: true })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
-    public async handler(event: APIGatewayProxyEvent, _context: any): Promise<APIGatewayProxyResult> {
+    public async handler(event: APIGatewayProxyEvent, _context: unknown): Promise<APIGatewayProxyResult> {
         try {
             const deserialisedRequestBody = JSON.parse(event.body as string);
             const requestBodyClientId = deserialisedRequestBody.client_id;

--- a/lambdas/src/types/audit-event.ts
+++ b/lambdas/src/types/audit-event.ts
@@ -19,7 +19,7 @@ export interface AuditEventSession {
 export interface AuditEventContext {
     sessionItem: AuditEventSession;
     personIdentity?: PersonIdentity;
-    extensions?: any;
+    extensions?: unknown;
     clientIpAddress: string | undefined;
 }
 
@@ -37,5 +37,5 @@ export interface AuditEvent {
     component_id: string;
     restricted?: PersonIdentity;
     user: AuditEventUser;
-    extensions?: any;
+    extensions?: unknown;
 }

--- a/lambdas/tests/unit/common/config/config-service.test.ts
+++ b/lambdas/tests/unit/common/config/config-service.test.ts
@@ -3,7 +3,7 @@ import { ClientConfigKey, CommonConfigKey } from "../../../../src/types/config-k
 import { ConfigService } from "../../../../src/common/config/config-service";
 
 const getMockSend = (key: CommonConfigKey, value?: string) => {
-    const mockPromise = new Promise<any>((resolve) => {
+    const mockPromise = new Promise<unknown>((resolve) => {
         resolve({
             Parameters: [
                 {
@@ -68,7 +68,7 @@ describe("ConfigService", () => {
         });
 
         it("should throw an error for an invalid client ID", async () => {
-            const mockPromise = new Promise<any>((resolve) => {
+            const mockPromise = new Promise<unknown>((resolve) => {
                 resolve({
                     Parameters: [],
                 });
@@ -86,7 +86,7 @@ describe("ConfigService", () => {
         });
 
         it("should throw an error for invalid parameters", async () => {
-            const mockPromise = new Promise<any>((resolve) => {
+            const mockPromise = new Promise<unknown>((resolve) => {
                 resolve({
                     Parameters: [],
                     InvalidParameters: ["invalid-param"],

--- a/lambdas/tests/unit/common/security/jwt-verifier.test.ts
+++ b/lambdas/tests/unit/common/security/jwt-verifier.test.ts
@@ -45,7 +45,7 @@ describe("jwt-verifier.ts", () => {
                     error: jest.fn(),
                 } as unknown as Logger;
                 publicKey = new Uint8Array([3, 101, 120, 26, 14, 184, 5, 99, 172, 149]);
-                jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as any);
+                jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
             });
 
             afterEach(() => {
@@ -70,12 +70,11 @@ describe("jwt-verifier.ts", () => {
                     sub: "some-subject",
                     aud: "some-audience",
                 };
-
                 importJWKMock.mockResolvedValueOnce(publicKey);
                 jwtVerifyMock.mockResolvedValueOnce({
                     payload: jwtPayload,
                     protectedHeader: {} as JWTHeaderParameters,
-                } as any);
+                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
 
                 const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
 
@@ -113,7 +112,7 @@ describe("jwt-verifier.ts", () => {
                 jwtVerifyMock.mockResolvedValueOnce({
                     payload: jwtPayload,
                     protectedHeader: {} as JWTHeaderParameters,
-                } as any);
+                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
 
                 const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
 
@@ -225,7 +224,7 @@ describe("jwt-verifier.ts", () => {
                 jwtVerifyMock.mockResolvedValueOnce({
                     payload: jwtPayload,
                     protectedHeader: {} as JWTHeaderParameters,
-                } as any);
+                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
 
                 const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
 
@@ -262,9 +261,13 @@ describe("jwt-verifier.ts", () => {
                 jwtVerifyMock.mockResolvedValueOnce({
                     payload: jwtPayload,
                     protectedHeader: {} as JWTHeaderParameters,
-                } as any);
+                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
 
-                const payload = await jwtVerifier.verify(encodedJwt, undefined as any, expectedClaimValues);
+                const payload = await jwtVerifier.verify(
+                    encodedJwt,
+                    undefined as unknown as Set<string>,
+                    expectedClaimValues,
+                );
 
                 expect(payload).toBeNull;
                 expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -12,6 +12,7 @@ import { SessionItem } from "../../../src/types/session-item";
 import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { ServerError } from "../../../src/types/errors";
 import { BearerAccessTokenFactory } from "../../../src/services/bearer-access-token-factory";
+import { JWTPayload } from "jose";
 
 jest.mock("../../../src/common/config/config-service");
 jest.mock("../../../src/common/security/jwt-verifier");
@@ -32,7 +33,7 @@ describe("access-token-handler.ts", () => {
     beforeEach(() => {
         jest.resetAllMocks();
         const impl = () => {
-            const mockPromise = new Promise<any>((resolve) => {
+            const mockPromise = new Promise<unknown>((resolve) => {
                 resolve({ Parameters: [] });
             });
             return jest.fn().mockImplementation(() => {
@@ -73,8 +74,8 @@ describe("access-token-handler.ts", () => {
                 );
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(true);
+                    new Promise<JWTPayload>((resolve) => {
+                        resolve(expect.anything());
                     }),
                 );
             });
@@ -122,7 +123,7 @@ describe("access-token-handler.ts", () => {
                 } as unknown as QueryCommandInput;
 
                 const impl = () => {
-                    const mockPromise = new Promise<any>((resolve) => {
+                    const mockPromise = new Promise<unknown>((resolve) => {
                         resolve(sessionItem);
                     });
                     return jest.fn().mockImplementation(() => {
@@ -175,7 +176,7 @@ describe("access-token-handler.ts", () => {
                 } as unknown as QueryCommandInput;
 
                 const impl = () => {
-                    const mockPromise = new Promise<any>((resolve) => {
+                    const mockPromise = new Promise<unknown>((resolve) => {
                         resolve(sessionItem);
                     });
                     return jest.fn().mockImplementation(() => {
@@ -246,8 +247,8 @@ describe("access-token-handler.ts", () => {
 
             it("should fail when session is not found", async () => {
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(true);
+                    new Promise<JWTPayload>((resolve) => {
+                        resolve(expect.anything());
                     }),
                 );
                 const redirectUri = "http://123.abc.com";
@@ -275,8 +276,8 @@ describe("access-token-handler.ts", () => {
 
             it("should fail when authorization code is not found", async () => {
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(true);
+                    new Promise<JWTPayload>((resolve) => {
+                        resolve(expect.anything());
                     }),
                 );
                 const redirectUri = "http://123.abc.com";
@@ -290,7 +291,7 @@ describe("access-token-handler.ts", () => {
                         client_assertion: "2",
                     },
                 } as unknown as APIGatewayProxyEvent;
-                const mockDynamoDbClientQueryResult: any = {
+                const mockDynamoDbClientQueryResult: unknown = {
                     Items: [
                         {
                             clientSessionId: "1",
@@ -304,11 +305,13 @@ describe("access-token-handler.ts", () => {
                 clientConfig.set("redirectUri", redirectUri);
 
                 jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(mockDynamoDbClientQueryResult);
+                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(
+                    mockDynamoDbClientQueryResult as void,
+                );
 
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(true);
+                    new Promise<JWTPayload>((resolve) => {
+                        resolve(expect.anything());
                     }),
                 );
 
@@ -351,7 +354,7 @@ describe("access-token-handler.ts", () => {
 
                 jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
 
-                const mockDynamoDbClientQueryResult: any = {
+                const mockDynamoDbClientQueryResult: unknown = {
                     Items: [
                         {
                             clientSessionId: "1",
@@ -361,7 +364,9 @@ describe("access-token-handler.ts", () => {
                     ],
                 };
 
-                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(mockDynamoDbClientQueryResult);
+                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(
+                    mockDynamoDbClientQueryResult as void,
+                );
 
                 const sessionItem = {
                     Items: [
@@ -379,7 +384,7 @@ describe("access-token-handler.ts", () => {
                 } as unknown as QueryCommandInput;
 
                 const impl = () => {
-                    const mockPromise = new Promise<any>((resolve) => {
+                    const mockPromise = new Promise<unknown>((resolve) => {
                         resolve(sessionItem);
                     });
                     return jest.fn().mockImplementation(() => {
@@ -412,7 +417,7 @@ describe("access-token-handler.ts", () => {
                         client_assertion: "2",
                     },
                 } as unknown as APIGatewayProxyEvent;
-                const mockDynamoDbClientQueryResult: any = {
+                const mockDynamoDbClientQueryResult: unknown = {
                     Items: [
                         {
                             clientSessionId: "1",
@@ -442,7 +447,7 @@ describe("access-token-handler.ts", () => {
                 } as unknown as QueryCommandInput;
 
                 const impl = () => {
-                    const mockPromise = new Promise<any>((resolve) => {
+                    const mockPromise = new Promise<unknown>((resolve) => {
                         resolve(sessionItem);
                     });
                     return jest.fn().mockImplementation(() => {
@@ -451,10 +456,12 @@ describe("access-token-handler.ts", () => {
                 };
                 mockDynamoDbClient.prototype.query = impl();
 
-                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(mockDynamoDbClientQueryResult);
+                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(
+                    mockDynamoDbClientQueryResult as void,
+                );
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(false);
+                    new Promise<null>((resolve) => {
+                        resolve(null);
                     }),
                 );
                 const output = await accessTokenLambda.handler(event, null);
@@ -474,8 +481,8 @@ describe("access-token-handler.ts", () => {
 
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(true);
+                    new Promise<JWTPayload>((resolve) => {
+                        resolve(expect.anything());
                     }),
                 );
 
@@ -489,7 +496,7 @@ describe("access-token-handler.ts", () => {
                 } as unknown as QueryCommandInput;
 
                 const impl = () => {
-                    const mockPromise = new Promise<any>((resolve) => {
+                    const mockPromise = new Promise<unknown>((resolve) => {
                         resolve(sessionItem);
                     });
                     return jest.fn().mockImplementation(() => {
@@ -546,7 +553,7 @@ describe("access-token-handler.ts", () => {
                 } as unknown as QueryCommandOutput;
 
                 mockDynamoDbClient.prototype.query.mockImplementation(() => {
-                    return new Promise<any>((resolve) => {
+                    return new Promise<JWTPayload>((resolve) => {
                         resolve(sessionItem);
                     });
                 });
@@ -575,8 +582,8 @@ describe("access-token-handler.ts", () => {
 
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(true);
+                    new Promise<JWTPayload>((resolve) => {
+                        resolve(expect.anything());
                     }),
                 );
 
@@ -590,7 +597,7 @@ describe("access-token-handler.ts", () => {
                 } as unknown as QueryCommandInput;
 
                 const impl = () => {
-                    const mockPromise = new Promise<any>((resolve) => {
+                    const mockPromise = new Promise<unknown>((resolve) => {
                         resolve(sessionItem);
                     });
                     return jest.fn().mockImplementation(() => {
@@ -623,8 +630,8 @@ describe("access-token-handler.ts", () => {
 
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
                 jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<any>((resolve) => {
-                        resolve(true);
+                    new Promise<JWTPayload>((resolve) => {
+                        resolve(expect.anything());
                     }),
                 );
 

--- a/lambdas/tests/unit/handlers/authorization-handler.test.ts
+++ b/lambdas/tests/unit/handlers/authorization-handler.test.ts
@@ -37,7 +37,7 @@ describe("authorization-handler.ts", () => {
     beforeEach(() => {
         jest.resetAllMocks();
         const impl = () => {
-            const mockPromise = new Promise<any>((resolve) => {
+            const mockPromise = new Promise<unknown>((resolve) => {
                 resolve({ Parameters: [] });
             });
             return jest.fn().mockImplementation(() => {
@@ -84,7 +84,7 @@ describe("authorization-handler.ts", () => {
                 authorizationCode: "abc",
             };
             jest.spyOn(sessionService, "getSession").mockReturnValue(
-                new Promise<any>((resolve) => {
+                new Promise<SessionItem>((resolve) => {
                     resolve(sessionItem);
                 }),
             );
@@ -155,7 +155,7 @@ describe("authorization-handler.ts", () => {
                     authorizationCode: undefined,
                 };
                 jest.spyOn(sessionService, "getSession").mockReturnValue(
-                    new Promise<any>((resolve) => {
+                    new Promise<SessionItem>((resolve) => {
                         resolve(sessionItem);
                     }),
                 );

--- a/lambdas/tests/unit/services/session-service.test.ts
+++ b/lambdas/tests/unit/services/session-service.test.ts
@@ -29,7 +29,7 @@ describe("session-service", () => {
         jest.resetAllMocks();
         sessionService = new SessionService(mockDynamoDbClient.prototype, configService);
         const impl = () => {
-            const mockPromise = new Promise<any>((resolve) => {
+            const mockPromise = new Promise<unknown>((resolve) => {
                 resolve({ Parameters: [] });
             });
             return jest.fn().mockImplementation(() => {


### PR DESCRIPTION
## Proposed changes

This is part of fixing eslinting errors, in this case no-implicit-any warnings are addressed
A separate PR would looking into fix the use of any in the catch block of the lambda handler
which is not as straight for as the fixes here

### What changed

Fix eslint warnings

### Why did it change

Code improvements recommended by eslint rules

### Issue tracking

- [OJ-1270](https://govukverify.atlassian.net/browse/OJ-1270)


[OJ-1270]: https://govukverify.atlassian.net/browse/OJ-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ