### PR TITLE
feat: non blocking switchable matrix

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -8,29 +8,40 @@ on:
 jobs:
   publish_common_cri_to_matrix_dev:
     strategy:
+      fail-fast: false
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, CIC_DEV ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, CIC_DEV, DL_DEV ]
         include:
           - target: ADDRESS_DEV
+            ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: ADDRESS_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: ADDRESS_DEV_SIGNING_PROFILE_NAME
           - target: FRAUD_DEV
+            ENABLED: "${{ vars.FRAUD_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: FRAUD_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: FRAUD_DEV_SIGNING_PROFILE_NAME
           - target: KBV_DEV
+            ENABLED: "${{ vars.KBV_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: KBV_DEV_SIGNING_PROFILE_NAME
           - target: KBV_POC
+            ENABLED: "${{ vars.KBV_POC_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: KBV_POC_SIGNING_PROFILE_NAME
           - target: CIC_DEV
+            ENABLED: "${{ vars.CIC_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: CIC_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: CIC_DEV_SIGNING_PROFILE_NAME
+          - target: DL_DEV
+            ENABLED: "${{ vars.DL_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: DL_DEV_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to dev
     runs-on: ubuntu-latest
@@ -41,32 +52,40 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        if: matrix.ENABLED == 'true'
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
+        if: matrix.ENABLED == 'true'
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
 
       - name: Setup Gradle
+        if: matrix.ENABLED == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.2
 
       - name: Setup SAM
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/setup-sam@v2
 
       - name: Assume temporary AWS role
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
+        if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
       - name: Generate code signing config
+        if: matrix.ENABLED == 'true'
         id: signing
         uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
         with:
@@ -74,9 +93,11 @@ jobs:
           profile: ${{ secrets[matrix.SIGNING_PROFILE_NAME] }}
 
       - name: SAM build
+        if: matrix.ENABLED == 'true'
         run: sam build -t infrastructure/lambda/template.yaml
 
       - name: SAM package
+        if: matrix.ENABLED == 'true'
         run: |
           sam package \
             ${{ steps.signing.outputs.signing_config }} \
@@ -84,9 +105,11 @@ jobs:
             --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
 
       - name: Zip the CloudFormation template
+        if: matrix.ENABLED == 'true'
         run: zip template.zip cf-template.yaml
 
       - name: Upload zipped CloudFormation artifact to S3
+        if: matrix.ENABLED == 'true'
         env:
           ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
         run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"
@@ -95,26 +118,32 @@ jobs:
   publish_common_cri_to_matrix_build:
     needs: publish_common_cri_to_matrix_dev
     strategy:
+      fail-fast: false
       matrix:
         target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, CIC_BUILD, DL_BUILD ]
         include:
           - target: ADDRESS_BUILD
+            ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    ADDRESS_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: ADDRESS_BUILD_SIGNING_PROFILE_NAME
           - target: FRAUD_BUILD
+            ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    FRAUD_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: FRAUD_BUILD_SIGNING_PROFILE_NAME
           - target: KBV_BUILD
+            ENABLED: "${{ vars.KBV_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    KBV_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: KBV_BUILD_SIGNING_PROFILE_NAME
           - target: CIC_BUILD
+            ENABLED: "${{ vars.CIC_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    CIC_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: CIC_BUILD_SIGNING_PROFILE_NAME
           - target: DL_BUILD
+            ENABLED: "${{ vars.DL_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: DL_BUILD_SIGNING_PROFILE_NAME
@@ -128,32 +157,40 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        if: matrix.ENABLED == 'true'
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
+        if: matrix.ENABLED == 'true'
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
 
       - name: Setup Gradle
+        if: matrix.ENABLED == 'true'
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.2
 
       - name: Setup SAM
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/setup-sam@v2
 
       - name: Assume temporary AWS role
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
+        if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
       - name: Generate code signing config
+        if: matrix.ENABLED == 'true'
         id: signing
         uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
         with:
@@ -161,9 +198,11 @@ jobs:
           profile: ${{ secrets[matrix.SIGNING_PROFILE_NAME] }}
 
       - name: SAM build
+        if: matrix.ENABLED == 'true'
         run: sam build -t infrastructure/lambda/template.yaml
 
       - name: SAM package
+        if: matrix.ENABLED == 'true'
         run: |
           sam package \
             ${{ steps.signing.outputs.signing_config }} \
@@ -171,9 +210,11 @@ jobs:
             --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
 
       - name: Zip the CloudFormation template
+        if: matrix.ENABLED == 'true'
         run: zip template.zip cf-template.yaml
 
       - name: Upload zipped CloudFormation artifact to S3
+        if: matrix.ENABLED == 'true'
         env:
           ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
         run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -118,140 +114,154 @@
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "9cfcc50fc0ad0be4e54b61eceb08f206528ef1c6",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 17
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "14ed1673466790e3f01675618c018d4ef9083ca9",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 18
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "903ffeaaff6ae224f320de93e49dc27666f877b9",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 22
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "84a189f3100c63f5fefb3ee3e661861a8d8ebf2d",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 23
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "2f2ae43baec845ea316514dea0279ecdce7b0362",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 27
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "fd4cb41e4ef40b21a7ef0320c30ca30dcf95206a",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 28
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "2d38b09c23f1b328ae854888abfe0cf47b45c64a",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d73fa283b0dc91b95f2ea1d555ebbdcbbfa43ab4",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 33
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "43f4abcd5d5e2cf1482fbda5bf4eadcdfc0a294c",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 37
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "64ababf589be883e6d09e73b1c050566f76aeb0f",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "99c84064f542ec25992874af52fae71443b6ed0e",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "83ffd716b650129c64f17ee886bc87a817903cc9",
+        "is_verified": false,
+        "line_number": 43
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d9c4666052c745e7c6f573d794aca9a4a6f3be8e",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 127
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "a526684ba66fb0f1d7c1bd531c70f1bf14db6a6a",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 142
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0aa77508d48646456f474415968125a444b86312",
         "is_verified": false,
-        "line_number": 115
+        "line_number": 143
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0ec0ad1e2eb3fcd03bcd813c6ade3927eb58c621",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f5f97a4d43698c40eb4eb208e2df8cd688479904",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 148
       }
     ],
     ".github/workflows/pre-merge-integration-test.yml": [
@@ -335,5 +345,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-20T12:25:30Z"
+  "generated_at": "2023-02-28T12:35:06Z"
 }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Common CRI secrets for Build environments:
 | KBV_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN             | Assumed role IAM ARN   |
 | KBV_BUILD_SIGNING_PROFILE_NAME                       | Signing profile name   |
 
+## Repository variables
+
+Each deployment requires a repository variable in the form CRINAME_DEST_ENABLED
+with the value set to true i.e. FRAUD_DEV_ENABLED KBV_BUILD_ENABLED
+
 ## Hooks
 
 **important:** One you've cloned the repo, run `pre-commit install` to install the pre-commit hooks.


### PR DESCRIPTION
## Proposed changes

This is an initial implementation of the non blocking matrix which implements fail-fast: false but does not prevent the corresponding build version of a failed deployment from attempting to run which will be added in another PR. This change also introduces switching of deployments on and off via setting repository variables, the default not to run if the corresponding variable is missing or set to false.

### What changed

* The matrixes have had the fail-fast strategy set to false 
* An ENABLED matrix variable has been added for each job run which is set via repository variables

### Why did it change

These changes have been made to:
* Prevent one CRI failure blocking the deployment for others
* Enable turning off of deployments without changing the workflow so that breaking changes can be controlled  

### Issue tracking

- [OJ-1234](https://govukverify.atlassian.net/browse/OJ-1234)

## Checklists

### Environment variables or secrets

- [X] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

Repository variables will need to be added to enable the deployments
 
- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1234]: https://govukverify.atlassian.net/browse/OJ-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ