### PR TITLE
Oj 1624 epoch changes in config service

### DIFF
--- a/lambdas/src/common/config/config-service.ts
+++ b/lambdas/src/common/config/config-service.ts
@@ -81,7 +81,7 @@ export class ConfigService {
 
     public getSessionExpirationEpoch() {
         const sessionTtl = parseInt(this.getConfigEntry(CommonConfigKey.SESSION_TTL), 10);
-        return Math.floor(((Date.now() + sessionTtl) * 1000) / 1000);
+        return Math.floor((Date.now() + sessionTtl * 1000) / 1000);
     }
 
     public getBearerAccessTokenTtl(): number {

--- a/lambdas/src/common/config/config-service.ts
+++ b/lambdas/src/common/config/config-service.ts
@@ -76,7 +76,7 @@ export class ConfigService {
     }
 
     public getAuthorizationCodeExpirationEpoch() {
-        return Math.floor(Date.now() + this.authorizationCodeTtlInMillis * 1000) / 1000;
+        return Math.floor(Date.now() + this.authorizationCodeTtlInMillis) / 1000;
     }
 
     public getSessionExpirationEpoch() {

--- a/lambdas/src/common/config/config-service.ts
+++ b/lambdas/src/common/config/config-service.ts
@@ -76,14 +76,12 @@ export class ConfigService {
     }
 
     public getAuthorizationCodeExpirationEpoch() {
-        // TODO: consider if this should be output in epoch seconds rather than milliseconds
-        // so that it is consistent with the java implementation
-        return Date.now() + this.authorizationCodeTtlInMillis;
+        return Math.floor(Date.now() + this.authorizationCodeTtlInMillis * 1000) / 1000;
     }
 
     public getSessionExpirationEpoch() {
         const sessionTtl = this.getConfigEntry(CommonConfigKey.SESSION_TTL);
-        return Date.now() + parseInt(sessionTtl, 10) * 1000;
+        return Math.floor(Date.now() + parseInt(sessionTtl, 10) * 1000) / 1000;
     }
 
     public getBearerAccessTokenTtl(): number {
@@ -91,7 +89,7 @@ export class ConfigService {
     }
 
     public getBearerAccessTokenExpirationEpoch(): number {
-        return Math.floor((new Date().getTime() + this.getBearerAccessTokenTtl() * 1000) / 1000);
+        return Math.floor((Date.now() + this.getBearerAccessTokenTtl() * 1000) / 1000);
     }
 
     private getParameterName(parameterNameSuffix: string) {

--- a/lambdas/src/common/config/config-service.ts
+++ b/lambdas/src/common/config/config-service.ts
@@ -76,12 +76,12 @@ export class ConfigService {
     }
 
     public getAuthorizationCodeExpirationEpoch() {
-        return Math.floor(Date.now() + this.authorizationCodeTtlInMillis) / 1000;
+        return Math.floor((Date.now() + this.authorizationCodeTtlInMillis) / 1000);
     }
 
     public getSessionExpirationEpoch() {
         const sessionTtl = this.getConfigEntry(CommonConfigKey.SESSION_TTL);
-        return Math.floor(Date.now() + parseInt(sessionTtl, 10) * 1000) / 1000;
+        return Math.floor((Date.now() + parseInt(sessionTtl, 10) * 1000) / 1000);
     }
 
     public getBearerAccessTokenTtl(): number {

--- a/lambdas/src/common/config/config-service.ts
+++ b/lambdas/src/common/config/config-service.ts
@@ -80,8 +80,8 @@ export class ConfigService {
     }
 
     public getSessionExpirationEpoch() {
-        const sessionTtl = this.getConfigEntry(CommonConfigKey.SESSION_TTL);
-        return Math.floor((Date.now() + parseInt(sessionTtl, 10) * 1000) / 1000);
+        const sessionTtl = parseInt(this.getConfigEntry(CommonConfigKey.SESSION_TTL), 10);
+        return Math.floor(((Date.now() + sessionTtl) * 1000) / 1000);
     }
 
     public getBearerAccessTokenTtl(): number {

--- a/lambdas/tests/unit/common/config/config-service.test.ts
+++ b/lambdas/tests/unit/common/config/config-service.test.ts
@@ -197,17 +197,17 @@ describe("ConfigService", () => {
     });
 
     describe("getSessionExpirationEpoch", () => {
-        jest.spyOn(global.Date, "now").mockReturnValueOnce(1675382400000);
+        jest.spyOn(global.Date, "now").mockReturnValue(1675382400000);
         it("should get the session expiration", async () => {
             mockSsmClient.prototype.send = getMockSend(CommonConfigKey.SESSION_TTL, "100");
             await configService.init([CommonConfigKey.SESSION_TABLE_NAME]);
             const epoch = configService.getSessionExpirationEpoch();
-            expect(epoch).toEqual(1675382500000);
+            expect(epoch).toEqual(1675382500);
         });
     });
 
     describe("getBearerAccessTokenExpirationEpoch", () => {
-        jest.spyOn(Date.prototype, "getTime").mockReturnValueOnce(1675382400000);
+        jest.spyOn(Date.prototype, "getTime").mockReturnValue(1675382400000);
         it("should return the ttl of the access token", () => {
             const output = configService.getBearerAccessTokenExpirationEpoch();
             expect(output).toEqual(1675382500);
@@ -216,17 +216,17 @@ describe("ConfigService", () => {
 
     describe("getAuthorizationCodeExpirationEpoch", () => {
         it("should get the authorization expiration", () => {
-            jest.spyOn(global.Date, "now").mockReturnValueOnce(1675382400000);
+            jest.spyOn(global.Date, "now").mockReturnValue(1675382400000);
             const epoch = configService.getAuthorizationCodeExpirationEpoch();
-            expect(epoch).toEqual(1675382500000);
+            expect(epoch).toEqual(1675382500);
         });
 
         it("should use the default expiration if not available", () => {
-            jest.spyOn(global.Date, "now").mockReturnValueOnce(1675382400000);
+            jest.spyOn(global.Date, "now").mockReturnValue(1675382400000);
             process.env.AUTHORIZATION_CODE_TTL = undefined;
             configService = new ConfigService(mockSsmClient.prototype);
             const epoch = configService.getAuthorizationCodeExpirationEpoch();
-            expect(epoch).toEqual(1675383000000);
+            expect(epoch).toEqual(1675383000);
         });
     });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

config-service.ts
config-service.test.ts

<!-- Describe the changes in detail - the "what"-->

### Why did it change

The current implementation uses milliseconds when we need epoch seconds to match Java land. 
config-service.test.test changes include changing the expected ms result to seconds as that's what the dynamo db table expects. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1624](https://govukverify.atlassian.net/browse/OJ-1624)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed
