### PR TITLE
fix: force non-blocking and correct var name

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -5,8 +5,11 @@ on:
       - main
   workflow_dispatch: # deploy manually
 
+  concurrency: post-merge-matrix-deploy
+
 jobs:
   publish_common_cri_to_matrix_dev:
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -116,7 +119,9 @@ jobs:
 
 
   publish_common_cri_to_matrix_build:
+  if: ${{ always() }}
     needs: publish_common_cri_to_matrix_dev
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +133,7 @@ jobs:
             GH_ACTIONS_ROLE_ARN_SECRET:    ADDRESS_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: ADDRESS_BUILD_SIGNING_PROFILE_NAME
           - target: FRAUD_BUILD
-            ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
+            ENABLED: "${{ vars.FRAUD_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    FRAUD_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: FRAUD_BUILD_SIGNING_PROFILE_NAME

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -114,154 +114,154 @@
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "9cfcc50fc0ad0be4e54b61eceb08f206528ef1c6",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "14ed1673466790e3f01675618c018d4ef9083ca9",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 21
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "903ffeaaff6ae224f320de93e49dc27666f877b9",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 25
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "84a189f3100c63f5fefb3ee3e661861a8d8ebf2d",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 26
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "2f2ae43baec845ea316514dea0279ecdce7b0362",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 30
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "fd4cb41e4ef40b21a7ef0320c30ca30dcf95206a",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "2d38b09c23f1b328ae854888abfe0cf47b45c64a",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 35
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d73fa283b0dc91b95f2ea1d555ebbdcbbfa43ab4",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 36
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "43f4abcd5d5e2cf1482fbda5bf4eadcdfc0a294c",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 40
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "64ababf589be883e6d09e73b1c050566f76aeb0f",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 41
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "99c84064f542ec25992874af52fae71443b6ed0e",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 45
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "83ffd716b650129c64f17ee886bc87a817903cc9",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 46
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d9c4666052c745e7c6f573d794aca9a4a6f3be8e",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 142
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 143
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "a526684ba66fb0f1d7c1bd531c70f1bf14db6a6a",
         "is_verified": false,
-        "line_number": 142
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0aa77508d48646456f474415968125a444b86312",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0ec0ad1e2eb3fcd03bcd813c6ade3927eb58c621",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 152
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f5f97a4d43698c40eb4eb208e2df8cd688479904",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 153
       }
     ],
     ".github/workflows/pre-merge-integration-test.yml": [
@@ -345,5 +345,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-28T12:35:06Z"
+  "generated_at": "2023-03-02T09:43:17Z"
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added concurrency to the workflow
Fixed fraud build enablement variable name
Force continue with continue-on-error and always

### Why did it change

Changed to prevent one CRI blocking another, to queue overlapping deployments and to fix incorrect variable 

### Issue tracking

- [OJ-1247](https://govukverify.atlassian.net/browse/OJ-1247)

## Checklists

### Environment variables or secrets

- [ ] Documented in the [README](./blob/main/README.md)
- [X] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1247]: https://govukverify.atlassian.net/browse/OJ-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ