### PR TITLE
PLAT-805: Passport CRI in post-merge GHA

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, CIC_DEV, DL_DEV ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, CIC_DEV, DL_DEV, PASSPORTA_DEV ]
         include:
           - target: ADDRESS_DEV
             ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
@@ -45,6 +45,11 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: DL_DEV_SIGNING_PROFILE_NAME
+          - target: PASSPORTA_DEV
+            ENABLED: "${{ vars.PASSPORTA_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: PASSPORTA_DEV_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to dev
     runs-on: ubuntu-latest
@@ -133,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, CIC_BUILD, DL_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, CIC_BUILD, DL_BUILD, PASSPORTA_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
@@ -160,6 +165,11 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: DL_BUILD_SIGNING_PROFILE_NAME
+          - target: PASSPORTA_BUILD
+            ENABLED: "${{ vars.PASSPORTA_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:    PASSPORTA_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: PASSPORTA_BUILD_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to build
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -200,72 +196,100 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "128c5d07564551d58ada2b8863eccaedffddcc49",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "6062421eba675dc39bd875b104c67871d6cc57c2",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d9c4666052c745e7c6f573d794aca9a4a6f3be8e",
-        "is_verified": false,
-        "line_number": 140
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
-        "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
         "line_number": 145
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
+        "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
         "is_verified": false,
         "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
+        "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
         "line_number": 150
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
+        "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
         "is_verified": false,
         "line_number": 151
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "a526684ba66fb0f1d7c1bd531c70f1bf14db6a6a",
+        "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
         "is_verified": false,
         "line_number": 155
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "0aa77508d48646456f474415968125a444b86312",
+        "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
         "is_verified": false,
         "line_number": 156
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "0ec0ad1e2eb3fcd03bcd813c6ade3927eb58c621",
+        "hashed_secret": "a526684ba66fb0f1d7c1bd531c70f1bf14db6a6a",
         "is_verified": false,
         "line_number": 160
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "f5f97a4d43698c40eb4eb208e2df8cd688479904",
+        "hashed_secret": "0aa77508d48646456f474415968125a444b86312",
         "is_verified": false,
         "line_number": 161
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "0ec0ad1e2eb3fcd03bcd813c6ade3927eb58c621",
+        "is_verified": false,
+        "line_number": 165
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "f5f97a4d43698c40eb4eb208e2df8cd688479904",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "2f9bddb21e782330751128eab5b0ee2bb32a8a5f",
+        "is_verified": false,
+        "line_number": 170
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "9a8444839c9ddc2bde47db07accb97180f3ef522",
+        "is_verified": false,
+        "line_number": 171
       }
     ],
     ".github/workflows/pre-merge-integration-test.yml": [
@@ -349,5 +373,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-08T13:17:46Z"
+  "generated_at": "2023-03-08T17:39:24Z"
 }


### PR DESCRIPTION
## Proposed changes

Passport CRI DEV and BUILD deployments configurations added to post-merge action

### Why did it change

To align passport CRI with common-cri best practices

### Issue tracking

- [PLAT-805](https://govukverify.atlassian.net/browse/PLAT-805)

### Environment variables or secrets

Secure pipeline secrets similar to existing CRIs 


[PLAT-805]: https://govukverify.atlassian.net/browse/PLAT-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ