### PR TITLE
OJ-1285 remove shared claims error and add conditional personal identity

### DIFF
--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -78,8 +78,13 @@ export class SessionLambda implements LambdaInterface {
             const sessionId: string = await this.sessionService.saveSession(sessionRequestSummary);
             logger.info("Session created");
 
-            await this.personIdentityService.savePersonIdentity(jwtPayload.shared_claims as PersonIdentity, sessionId);
-            logger.info("Personal identity created");
+            if (jwtPayload.shared_claims) {
+                await this.personIdentityService.savePersonIdentity(
+                    jwtPayload.shared_claims as PersonIdentity,
+                    sessionId,
+                );
+                logger.info("Personal identity created");
+            }
 
             await this.sendAuditEvent(sessionId, sessionRequestSummary, clientIpAddress);
 

--- a/lambdas/src/services/session-request-validator.ts
+++ b/lambdas/src/services/session-request-validator.ts
@@ -16,11 +16,6 @@ export class SessionRequestValidator {
                 "Session Validation Exception",
                 "Invalid request: JWT validation/verification failed: JWT verification failure",
             );
-        } else if (!payload.shared_claims) {
-            throw new SessionValidationError(
-                "Session Validation Exception",
-                "Invalid request: JWT validation/verification failed: JWT payload missing shared claims",
-            );
         } else if (payload.client_id !== requestBodyClientId) {
             throw new SessionValidationError(
                 "Session Validation Exception",

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -222,6 +222,26 @@ describe("SessionLambda", () => {
         expect(spy).toHaveBeenCalledWith(mockPerson, "test-session-id");
     });
 
+    it("should not save the personal identity information is no shared claims are available", async () => {
+        jest.spyOn(sessionRequestValidator.prototype, "validateJwt").mockReturnValue(
+            new Promise<JWTPayload>((res) =>
+                res({
+                    client_id: "test-jwt-client-id",
+                    govuk_signin_journey_id: "test-journey-id",
+                    persistent_session_id: "test-persistent-session-id",
+                    redirect_uri: "test-redirect-uri",
+                    state: "test-state",
+                    sub: "test-sub",
+                } as JWTPayload),
+            ),
+        );
+
+        const spy = jest.spyOn(personIdentityService.prototype, "savePersonIdentity");
+        await sessionLambda.handler(mockEvent, {});
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+
     it("should send the audit event", async () => {
         const spy = jest.spyOn(auditService.prototype, "sendAuditEvent");
         await sessionLambda.handler(mockEvent, {});

--- a/lambdas/tests/unit/services/session-request-validator.test.ts
+++ b/lambdas/tests/unit/services/session-request-validator.test.ts
@@ -39,20 +39,6 @@ describe("session-request-validator.ts", () => {
             );
         });
 
-        it("should return an error on JWT verification failure", async () => {
-            const jwtPayload = jest.mocked({} as JWTPayload);
-            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValueOnce(jwtPayload);
-
-            await expect(
-                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), "request-client-id"),
-            ).rejects.toThrow(
-                expect.objectContaining({
-                    message: "Session Validation Exception",
-                    details: "Invalid request: JWT validation/verification failed: JWT payload missing shared claims",
-                }),
-            );
-        });
-
         it("should return anerror on mismatched client ID", async () => {
             jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
                 new Promise<JWTPayload | null>((res) =>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Remove the error on missing shared claims
Add conditional logic to whether the personal identity information is saved

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
The error is not present in the Java lambda and was causing the address cri stub to error
The personal identity information cannot be saved without shared claims and would cause another error if attempted
The ticket to fix this and re-implement the TS error once the TS lamdbas have been released and are working in prod is here 
https://govukverify.atlassian.net/browse/OJ-1294

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1285](https://govukverify.atlassian.net/browse/OJ-1285)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1285]: https://govukverify.atlassian.net/browse/OJ-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ