### PR TITLE
Oj-1287: create authcode lambda for premerge

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -279,7 +283,7 @@
         "filename": "infrastructure/lambda/pre-merge-api.yaml",
         "hashed_secret": "01613fb1bb441c88d5e6773e2813ee026ad5b928",
         "is_verified": false,
-        "line_number": 175
+        "line_number": 210
       }
     ],
     "infrastructure/lambda/template.yaml": [
@@ -345,5 +349,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-06T14:21:25Z"
+  "generated_at": "2023-03-08T13:17:46Z"
 }

--- a/authorization/src/main/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandler.java
+++ b/authorization/src/main/java/uk/gov/di/ipv/cri/common/api/handler/AuthorizationHandler.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse;
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.logging.log4j.Level;
 import software.amazon.awssdk.http.HttpStatusCode;
@@ -30,7 +29,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.logging.log4j.Level.ERROR;
-import static org.apache.logging.log4j.Level.INFO;
 
 public class AuthorizationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -73,15 +71,6 @@ public class AuthorizationHandler
                     .log(Level.INFO, "found session");
             // validate
             authorizationValidatorService.validate(authenticationRequest, sessionItem);
-
-            // create authorization if not already present
-            if (StringUtils.isBlank(sessionItem.getAuthorizationCode())) {
-                sessionService.createAuthorizationCode(sessionItem);
-                eventProbe.log(
-                        INFO,
-                        "Authorization code not present. Authorization code generated successfully.");
-            }
-
             AuthorizationSuccessResponse authorizationSuccessResponse =
                     new AuthorizationSuccessResponse(
                             authenticationRequest.getRedirectionURI(),

--- a/infrastructure/lambda/pre-merge-api.yaml
+++ b/infrastructure/lambda/pre-merge-api.yaml
@@ -5,6 +5,41 @@ info:
 
 paths:
 
+  /pre-merge-create-auth-code:
+      get:
+        parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+        responses:
+          "200":
+            description: A successful response with an authorization code
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    authCode:
+                      type: string
+                      description: The authorization code for premerge
+          "400":
+            description: A bad request error with a message
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Error"
+          "500":
+            description: An internal server error with a message
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Error"
+        x-amazon-apigateway-request-validator: "Validate both"
+        x-amazon-apigateway-integration:
+          type: "aws_proxy"
+          httpMethod: "POST"
+          uri:
+            Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreateAuthCodeFunction.Arn}/invocations
+          passthroughBehavior: "when_no_match"
+
   /authorization:
     get:
       parameters:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -869,6 +869,46 @@ Resources:
               ArnLike:
                 "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
 
+  CreateAuthCodeFunction:
+    Type: AWS::Serverless::Function
+    Condition: IsDevEnvironment
+    Properties:
+      Handler: create-auth-code-handler.lambdaHandler
+      CodeUri: ../../lambdas
+      Runtime: nodejs18.x
+      FunctionName: !Sub "${AWS::StackName}-CreateAuthCodeFunction"
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-create-auth-code"
+      Policies:
+        - DynamoDBWritePolicy:
+            TableName:
+              Ref: SessionTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameters
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
+    Metadata: # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "esnext"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/create-auth-code-handler.ts
+        External:
+          - '@aws-sdk/*'
+
+  CreateAuthCodeFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsDevEnvironment
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt CreateAuthCodeFunction.Arn
+      Principal: apigateway.amazonaws.com
 
   PreMergeDevOnlyApi:
     Type: AWS::Serverless::Api

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -16,6 +16,7 @@ import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.UUID;
 
+import static gov.uk.di.ipv.cri.common.api.util.IpvCoreStubUtil.sendCreateAuthCodeRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -173,5 +174,11 @@ public class APISteps {
     public void userSendsARequestToAccessTokenEndPointWithIncorrectAuthorizationCode()
             throws URISyntaxException, IOException, InterruptedException {
         response = IpvCoreStubUtil.sendAccessTokenRequest("wrong_authorization_code");
+    }
+
+    @When("session has an authCode")
+    public void sessionHasAnAuthCode()
+            throws URISyntaxException, IOException, InterruptedException {
+        sendCreateAuthCodeRequest(currentSessionId);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -5,6 +5,7 @@ import org.apache.http.client.utils.URIBuilder;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -19,7 +20,7 @@ public class IpvCoreStubUtil {
     private static final String ADDRESS_CRI_DEV = "address-cri-dev";
     private static final String API_GATEWAY_ID_PRIVATE = "API_GATEWAY_ID_PRIVATE";
 
-    private static String getPrivateApiEndpoint() {
+    public static String getPrivateApiEndpoint() {
         String apiEndpoint = System.getenv(API_GATEWAY_ID_PRIVATE);
         Optional.ofNullable(apiEndpoint)
                 .orElseThrow(
@@ -126,15 +127,30 @@ public class IpvCoreStubUtil {
                         .addParameter("scope", "openid")
                         .addParameter("state", "state-ipv")
                         .build();
+        HttpRequest request = getHttpRequest(sessionId, url);
+
+        return sendHttpRequest(request);
+    }
+
+    public static void sendCreateAuthCodeRequest(String sessionId)
+            throws URISyntaxException, IOException, InterruptedException {
         var request =
-                HttpRequest.newBuilder()
-                        .uri(url)
+                getHttpRequest(
+                        sessionId,
+                        new URIBuilder(getPrivateApiEndpoint())
+                                .setPath("dev/pre-merge-create-auth-code")
+                                .build());
+        sendHttpRequest(request);
+    }
+
+    private static HttpRequest getHttpRequest(String sessionId, URI url) throws URISyntaxException {
+        var request =
+                HttpRequest.newBuilder(url)
                         .setHeader("Accept", "application/json")
                         .setHeader("session-id", sessionId)
                         .GET()
                         .build();
-
-        return sendHttpRequest(request);
+        return request;
     }
 
     public static HttpResponse<String> sendAccessTokenRequest(String authorizationCode)

--- a/integration-tests/src/test/resources/features/AccessTokenAPI.feature
+++ b/integration-tests/src/test/resources/features/AccessTokenAPI.feature
@@ -5,6 +5,7 @@ Feature: Access Token API
     And Session lambda implementation is in '<SessionLambdaImplementation>'
     When user sends a request to session API
     Then user gets a session id
+    When session has an authCode
     And Authorisation lambda implementation is in '<AuthLambdaImplementation>'
     When user sends a valid request to authorization end point
     Then expect a status code of 200 in the response
@@ -29,6 +30,7 @@ Feature: Access Token API
     And Session lambda implementation is in '<SessionLambdaImplementation>'
     When user sends a request to session API
     Then user gets a session id
+    When session has an authCode
     And Authorisation lambda implementation is in '<AuthLambdaImplementation>'
     When user sends a valid request to authorization end point
     Then expect a status code of 200 in the response

--- a/integration-tests/src/test/resources/features/AuthorizationAPI.feature
+++ b/integration-tests/src/test/resources/features/AuthorizationAPI.feature
@@ -5,6 +5,7 @@ Feature: Authorization API
     And Session lambda implementation is in '<SessionLambdaImplementation>'
     When user sends a request to session API
     Then user gets a session id
+    When session has an authCode
     And Authorisation lambda implementation is in '<AuthLambdaImplementation>'
     When user sends a valid request to authorization end point
     Then expect a status code of 200 in the response
@@ -21,6 +22,7 @@ Feature: Authorization API
     And Session lambda implementation is in '<SessionLambdaImplementation>'
     When user sends a request to session API
     Then user gets a session id
+    When session has an authCode
     And Authorisation lambda implementation is in '<AuthLambdaImplementation>'
     When user sends a request to authorization end point with invalid client id
     Then expect a status code of 400 in the response
@@ -37,6 +39,7 @@ Feature: Authorization API
     And Session lambda implementation is in '<SessionLambdaImplementation>'
     When user sends a request to session API
     Then user gets a session id
+    When session has an authCode
     And Authorisation lambda implementation is in '<AuthLambdaImplementation>'
     When user sends a request to authorization end point with invalid redirect uri
     Then expect a status code of 400 in the response

--- a/lambdas/jest.config.ts
+++ b/lambdas/jest.config.ts
@@ -16,7 +16,7 @@ export default {
     ],
     coverageDirectory: "coverage",
     coverageProvider: "v8",
-    coveragePathIgnorePatterns: ["config.ts", "node_modules/"],
+    coveragePathIgnorePatterns: ["src/handlers/create-auth-code-handler.ts","config.ts", "node_modules/"],
     coverageThreshold: {
         global: {
             statements: 95,

--- a/lambdas/src/handlers/authorization-handler.ts
+++ b/lambdas/src/handlers/authorization-handler.ts
@@ -54,11 +54,6 @@ export class AuthorizationLambda implements LambdaInterface {
             logger.info("Session validated");
             logger.appendKeys({ govuk_signin_journey_id: sessionItem.clientSessionId });
 
-            if (!sessionItem.authorizationCode) {
-                await this.sessionService.createAuthorizationCode(sessionItem);
-                logger.info("Authorization code not present. Authorization code generated successfully.");
-            }
-
             const authorizationResponse = {
                 state: {
                     value: event.queryStringParameters?.["state"],

--- a/lambdas/src/handlers/create-auth-code-handler.ts
+++ b/lambdas/src/handlers/create-auth-code-handler.ts
@@ -1,0 +1,54 @@
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { DynamoDBDocument, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { randomUUID } from "crypto";
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { AwsClientType, createClient } from "../common/aws-client-factory";
+import { ConfigService } from "../common/config/config-service";
+import { getSessionId } from "../common/utils/request-utils";
+import { CommonConfigKey } from "../types/config-keys";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { errorPayload } from "../types/errors";
+
+const dynamoDbClient = createClient(AwsClientType.DYNAMO) as DynamoDBDocument;
+const ssmClient = createClient(AwsClientType.SSM) as SSMClient;
+const logger = new Logger();
+const configService = new ConfigService(ssmClient);
+const initPromise = configService.init([CommonConfigKey.SESSION_TABLE_NAME]);
+
+export class CreateAuthCodeLambda implements LambdaInterface {
+    constructor(private readonly configService: ConfigService, private readonly dynamoDbClient: DynamoDBDocument) {}
+
+    @logger.injectLambdaContext({ clearState: true })
+    public async handler(
+        event: APIGatewayProxyEvent,
+        _context: unknown,
+    ): Promise<APIGatewayProxyResult | { statusCode: number }> {
+        try {
+            await initPromise;
+            logger.info("Create AuthCode Lambda triggered");
+
+            const sessionId = getSessionId(event);
+            const authorizationCode = randomUUID();
+
+            await this.dynamoDbClient.send(
+                new UpdateCommand({
+                    TableName: this.configService.getConfigEntry(CommonConfigKey.SESSION_TABLE_NAME),
+                    Key: { sessionId: sessionId },
+                    UpdateExpression: "SET authorizationCode=:authCode, authorizationCodeExpiryDate=:authCodeExpiry",
+                    ExpressionAttributeValues: {
+                        ":authCode": authorizationCode,
+                        ":authCodeExpiry": this.configService.getAuthorizationCodeExpirationEpoch(),
+                    },
+                }),
+            );
+            logger.info(`AuthCode Created on Session with Id: ${sessionId}`);
+            return { statusCode: 200 };
+        } catch (err: unknown) {
+            return errorPayload(err as Error, logger, "Create AuthCode Lambda error occurred");
+        }
+    }
+}
+
+const handlerClass = new CreateAuthCodeLambda(configService, dynamoDbClient);
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/tests/unit/handlers/authorization-handler.test.ts
+++ b/lambdas/tests/unit/handlers/authorization-handler.test.ts
@@ -142,35 +142,6 @@ describe("authorization-handler.ts", () => {
                 expect(loggerSpyAppendkeys).toBeCalledWith({ govuk_signin_journey_id: "1" });
                 expect(metricsSpyAddMetrics).toBeCalledWith("authorization_sent", "Count", 1);
             });
-
-            it("should create an auth code if not available", async () => {
-                const sessionItem: SessionItem = {
-                    sessionId: "abc",
-                    authorizationCodeExpiryDate: 1,
-                    clientId: "1",
-                    clientSessionId: "1",
-                    redirectUri: "http://123.com",
-                    accessToken: "",
-                    accessTokenExpiryDate: 0,
-                    authorizationCode: undefined,
-                };
-                jest.spyOn(sessionService, "getSession").mockReturnValue(
-                    new Promise<SessionItem>((resolve) => {
-                        resolve(sessionItem);
-                    }),
-                );
-                const createSpy = jest.spyOn(sessionService, "createAuthorizationCode");
-
-                await authorizationHandlerLambda.handler(
-                    {
-                        body,
-                        headers,
-                        queryStringParameters: queryString,
-                    } as unknown as APIGatewayProxyEvent,
-                    null,
-                );
-                expect(createSpy).toHaveBeenCalledWith(sessionItem);
-            });
         });
 
         describe("authorization request has missing attributes", () => {


### PR DESCRIPTION
## Proposed changes

Remove the creation of [AuthCode ](https://github.com/alphagov/di-ipv-cri-common-lambdas/pull/57)in the AuthorizationCodeHandler 
see: https://github.com/alphagov/di-ipv-cri-common-lambdas/pull/57

The common lambda intergration test still require an AuthCode to be in the session table. In the normal code flow the responsibility lies with credential issuers this is still the case see [KBV](https://github.com/alphagov/di-ipv-cri-kbv-api/blob/main/lambdas/answer/src/main/java/uk/gov/di/ipv/cri/kbv/api/handler/QuestionAnswerHandler.java#L171) and [ADDRESS](https://github.com/alphagov/di-ipv-cri-address-api/blob/main/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java#L88)

An new [endpoint ](https://github.com/alphagov/di-ipv-cri-common-lambdas/blob/d8669fc3a5d816e0b754188aae4230421012abc4/infrastructure/lambda/pre-merge-api.yaml#L8)is introduced call `/pre-merge-create-auth-code`

This resources behind this endpoint is constraint to the development environment using   `Condition: IsDevEnvironment`
in the SAM template file

### What changed

See: [LIME-443](https://govukverify.atlassian.net/browse/LIME-443)

### Why did it change

Common lambda Integration Test introduced a bug discovered from the above, 
This PR addresses this

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-443](https://govukverify.atlassian.net/browse/LIME-443)
- [OJ-1287](https://govukverify.atlassian.net/browse/OJ-1287)
### Other considerations



[LIME-443]: https://govukverify.atlassian.net/browse/LIME-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ