### PR TITLE
OJ-1258: Added scope and state checks for JWT

### DIFF
--- a/lambdas/src/common/security/jwt-verifier.ts
+++ b/lambdas/src/common/security/jwt-verifier.ts
@@ -12,6 +12,8 @@ export enum ClaimNames {
     ISSUED_AT = "iat",
     JWT_ID = "jti",
     REDIRECT_URI = "redirect_uri",
+    SCOPE = "scope",
+    STATE = "state",
 }
 
 export class JwtVerifier {

--- a/lambdas/tests/unit/services/session-request-validator.test.ts
+++ b/lambdas/tests/unit/services/session-request-validator.test.ts
@@ -7,17 +7,18 @@ import {
 } from "../../../src/services/session-request-validator";
 import { ClientConfigKey } from "../../../src/types/config-keys";
 import { PersonIdentity } from "../../../src/types/person-identity";
+import { SessionRequestValidationConfig } from "../../../src/types/session-request-validation-config";
 
 describe("session-request-validator.ts", () => {
     const logger = new Logger();
     const mockMap = new Map<string, string>();
     mockMap.set("session-id", "test-session-id");
     const personIdentity = jest.mocked({} as PersonIdentity);
+    const jwtVerifier = jest.mocked(JwtVerifier);
 
     describe("SessionRequestValidator", () => {
         let sessionRequestValidatorFactory: SessionRequestValidatorFactory;
         let sessionRequestValidator: SessionRequestValidator;
-        const jwtVerifier = jest.mocked(JwtVerifier);
 
         beforeEach(() => {
             sessionRequestValidatorFactory = new SessionRequestValidatorFactory(logger);
@@ -106,11 +107,15 @@ describe("session-request-validator.ts", () => {
         });
 
         it("should successfully validate the jwt", async () => {
+            const scope = "openid";
+            const state = "state";
             jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
                 new Promise<JWTPayload | null>((res) =>
                     res({
                         client_id: "request-client-id",
                         redirect_uri: "redirect-uri",
+                        scope: scope,
+                        state: state,
                         shared_claims: personIdentity,
                     } as JWTPayload),
                 ),
@@ -122,8 +127,133 @@ describe("session-request-validator.ts", () => {
             expect(response).toEqual({
                 client_id: "request-client-id",
                 redirect_uri: "redirect-uri",
+                scope: scope,
+                state: state,
                 shared_claims: personIdentity,
             });
+        });
+    });
+
+    describe("sessionRequestValidator", () => {
+        let sessionRequestValidator: SessionRequestValidator;
+        let sessionRequestValidationConfig: SessionRequestValidationConfig;
+        const jwtVerifier = jest.mocked(JwtVerifier);
+
+        beforeEach(() => {
+            sessionRequestValidationConfig = {
+                expectedJwtRedirectUri: "redirect-uri",
+            } as SessionRequestValidationConfig;
+
+            sessionRequestValidator = new SessionRequestValidator(
+                sessionRequestValidationConfig,
+                jwtVerifier.prototype,
+            );
+        });
+
+        it("should pass when jwt body is correct", async () => {
+            const client_id = "request-client-id";
+            const redirect_uri = "redirect-uri";
+            const scope = "openid";
+            const state = "state";
+
+            const jwtPayload = {
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                scope: scope,
+                state: state,
+                shared_claims: personIdentity,
+            } as JWTPayload;
+
+            jest.spyOn(sessionRequestValidator, "verifyJwtSignature").mockReturnValue(
+                new Promise<JWTPayload | null>((res) => res(jwtPayload)),
+            );
+
+            const payload = (await sessionRequestValidator.validateJwt(
+                Buffer.from("test-jwt"),
+                client_id,
+            )) as JWTPayload;
+
+            await expect(payload).toEqual(jwtPayload);
+        });
+
+        it("should fail to validate the jwt if scope is not openid", async () => {
+            const client_id = "request-client-id";
+            const redirect_uri = "redirect-uri";
+            const scope = "test";
+            const state = "state";
+
+            jest.spyOn(sessionRequestValidator, "verifyJwtSignature").mockReturnValue(
+                new Promise<JWTPayload | null>((res) =>
+                    res({
+                        client_id: client_id,
+                        redirect_uri: redirect_uri,
+                        scope: scope,
+                        state: state,
+                        shared_claims: personIdentity,
+                    } as JWTPayload),
+                ),
+            );
+
+            await expect(async () =>
+                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
+            ).rejects.toThrow(
+                expect.objectContaining({
+                    message: "Session Validation Exception",
+                    details: "Invalid scope parameter",
+                }),
+            );
+        });
+
+        it("should fail to validate the jwt if scope is missing", async () => {
+            const client_id = "request-client-id";
+            const redirect_uri = "redirect-uri";
+            const state = "state";
+
+            jest.spyOn(sessionRequestValidator, "verifyJwtSignature").mockReturnValue(
+                new Promise<JWTPayload | null>((res) =>
+                    res({
+                        client_id: client_id,
+                        redirect_uri: redirect_uri,
+                        state: state,
+                        shared_claims: personIdentity,
+                    } as JWTPayload),
+                ),
+            );
+
+            await expect(async () =>
+                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
+            ).rejects.toThrow(
+                expect.objectContaining({
+                    message: "Session Validation Exception",
+                    details: "Invalid scope parameter",
+                }),
+            );
+        });
+
+        it("should fail to validate the jwt if state is missing", async () => {
+            const client_id = "request-client-id";
+            const redirect_uri = "redirect-uri";
+            const scope = "openid";
+
+            jest.spyOn(sessionRequestValidator, "verifyJwtSignature").mockReturnValue(
+                new Promise<JWTPayload | null>((res) =>
+                    res({
+                        client_id: client_id,
+                        redirect_uri: redirect_uri,
+                        scope: scope,
+                        shared_claims: personIdentity,
+                    } as JWTPayload),
+                ),
+            );
+
+            await expect(async () =>
+                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
+            ).rejects.toThrow(
+                expect.objectContaining({
+                    message: "Session Validation Exception",
+                    details: "Invalid state parameter",
+                }),
+            );
         });
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated SessionRequestValidator to check if scope is openid and that a state is present within the JWT.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
In the Java code, the Nimbus JOSE library threw an exception when scope was missing. As this was not a custom error that we threw, it was missed when doing the Typescript conversion. This is needed functionality. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1258](https://govukverify.atlassian.net/browse/OJ-1258)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed
