### PR TITLE
fix: JWT verification issue due to JWK without alg

### DIFF
--- a/lambdas/src/common/security/jwt-verifier.ts
+++ b/lambdas/src/common/security/jwt-verifier.ts
@@ -27,7 +27,7 @@ export class JwtVerifier {
             const signingPublicJwkBase64 = this.jwtVerifierConfig.publicSigningJwk;
             const signingAlgorithm = this.jwtVerifierConfig.jwtSigningAlgorithm;
             const signingPublicJwk = JSON.parse(Buffer.from(signingPublicJwkBase64, "base64").toString("utf8"));
-            const publicKey = await importJWK(signingPublicJwk, signingPublicJwk.alg);
+            const publicKey = await importJWK(signingPublicJwk, signingPublicJwk?.alg || signingAlgorithm);
 
             const jwtVerifyOptions = this.createJwtVerifyOptions(signingAlgorithm, expectedClaimValues);
             const { payload } = await jwtVerify(encodedJwt, publicKey, jwtVerifyOptions);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When using the TypeScript lambdas with core-stub they work fine, but coming in through the orchestrator stub there are issues.

The error message contains to
```
TypeError: \"alg\" argument is required when \"jwk.alg\" is not present
```

This suggests there is a difference in the signing key, which is overridable by config coming in via the authenticationAlg parameter

This PR defaults to the signing key alg, and falls back to the alg defined as a parameter
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1286](https://govukverify.atlassian.net/browse/OJ-1286)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1286]: https://govukverify.atlassian.net/browse/OJ-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ