### PR TITLE
OJ-1302: Fix information leak in log message

### DIFF
--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
@@ -111,7 +111,7 @@ public class SessionRequestService {
 
             return sessionRequest;
         } catch (JsonProcessingException | ParseException e) {
-            throw new SessionValidationException("Could not parse request body", e);
+            throw new SessionValidationException("Could not parse request body");
         }
     }
 

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestServiceTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestServiceTest.java
@@ -179,6 +179,7 @@ class SessionRequestServiceTest {
             ex.printStackTrace(new PrintWriter(sw));
             String stacktrace = sw.toString();
             assertFalse(stacktrace.contains(birthdaySharedClaim));
+            assertTrue(ex.getMessage().equals("Could not parse request body"));
         }
     }
 

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestServiceTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestServiceTest.java
@@ -2,10 +2,13 @@ package uk.gov.di.ipv.cri.common.api.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,21 +24,20 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.JWTVerifier;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URI;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.text.ParseException;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class SessionRequestServiceTest {
@@ -135,6 +137,51 @@ class SessionRequestServiceTest {
                 exception.getMessage(),
                 containsString("could not parse request body to signed JWT"));
     }
+
+    @Test
+    void shouldFailOnInvalidDOBInClaims() throws Exception {
+        sessionRequestService =
+                new SessionRequestService(
+                        new ObjectMapper().registerModule(new JavaTimeModule()),
+                        mockJwtVerifier,
+                        mockConfigurationService,
+                        mockJwtDecrypter);
+
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("client_id", "client-id");
+        requestBody.put("requestJWT", "request");
+
+        String birthdaySharedClaim = "{\"birthDate\": [{\"value\": \"1965-0-0\"}]}";
+
+        JWSHeader header = new JWSHeader(new JWSAlgorithm("suraj-test"));
+        JWTClaimsSet claimsSet = new JWTClaimsSet
+                .Builder()
+                .claim("client_id", "test-value")
+                .claim("test", "test-value")
+                .claim("redirect_uri", "test-value")
+                .claim("state", "test-value")
+                .claim("persistent_session_id", "test-value")
+                .claim("govuk_signin_journey_id", "test-value")
+                .claim("shared_claims", birthdaySharedClaim)
+                .audience(List.of("aud"))
+                .expirationTime(new Date())
+                .issuer("iss")
+                .build();
+        SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+        when(mockJwtDecrypter.decrypt("request")).thenReturn(signedJWT);
+
+        try {
+            given(sessionRequestService.validateSessionRequest(requestBody.toString())).willThrow(SessionValidationException.class);
+            fail("Expected SessionValidationException to be thrown");
+        } catch (SessionValidationException ex) {
+            ex.printStackTrace();
+            StringWriter sw = new StringWriter();
+            ex.printStackTrace(new PrintWriter(sw));
+            String stacktrace = sw.toString();
+            assertFalse(stacktrace.contains(birthdaySharedClaim));
+        }
+    }
+
 
     @Test
     void shouldValidateJWTSignedWithECKey()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The SessionRequestService.parseSessionRequest has been updated to not include the full error.
Unit test has been added to test this.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
When a bad JSON is passed to Jackson, the exception contains the full JSON error within the stacktrace which gets leaked into logs. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1302](https://govukverify.atlassian.net/browse/OJ-1302)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed