### PR TITLE
fix: update configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Python
         if: matrix.ENABLED == 'true'
         uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: 3.11.2
 
       - name: Setup Gradle
@@ -91,7 +91,7 @@ jobs:
 
       - name: Assume temporary AWS role
         if: matrix.ENABLED == 'true'
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}
@@ -194,7 +194,7 @@ jobs:
       - name: Setup Python
         if: matrix.ENABLED == 'true'
         uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: 3.11.2
 
       - name: Setup Gradle
@@ -211,7 +211,7 @@ jobs:
 
       - name: Assume temporary AWS role
         if: matrix.ENABLED == 'true'
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Proposed changes

### What changed

The configure-aws-credentials action v1-node16 was failing due to a node12 reference which is no longer supported by GitHub. Version 2 has been released last week which resolves this issue. 

### Why did it change

To fix the failing workflows

### Issue tracking

- [OJ-1346-](https://govukverify.atlassian.net/browse/OJ-1346)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
