### PR TITLE
Oj-1413: use middy in access token lambda

### DIFF
--- a/lambdas/src/common/utils/errors.ts
+++ b/lambdas/src/common/utils/errors.ts
@@ -1,7 +1,7 @@
 import { Logger } from "@aws-lambda-powertools/logger";
 // Implementation of ErrorResponse.java in di-ipv-cri-lib
 
-interface ErrorResponse {
+export interface ErrorResponse {
     statusCode: number;
     body: string;
 }

--- a/lambdas/src/common/utils/power-tool.ts
+++ b/lambdas/src/common/utils/power-tool.ts
@@ -1,0 +1,9 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Tracer } from "@aws-lambda-powertools/tracer";
+
+const logger = new Logger();
+const metrics = new Metrics();
+const tracer = new Tracer({ captureHTTPsRequests: false });
+
+export { logger, metrics, tracer };

--- a/lambdas/src/common/utils/request-utils.ts
+++ b/lambdas/src/common/utils/request-utils.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEvent } from "aws-lambda";
-import { InvalidRequestError } from "../../types/errors";
+import { InvalidRequestError } from "./errors";
 
 const getHeaderValue = (event: APIGatewayProxyEvent, desiredHeader: string) => {
     // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -1,28 +1,27 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
-import { Logger } from "@aws-lambda-powertools/logger";
+import middy from "@middy/core";
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
 import { SessionService } from "../services/session-service";
-import { ConfigService } from "../common/config/config-service";
 import { AccessTokenRequestValidator } from "../services/token-request-validator";
 import { JwtVerifierFactory } from "../common/security/jwt-verifier";
+import { ClientConfigKey } from "../types/config-keys";
+import { BearerAccessTokenFactory } from "../services/bearer-access-token-factory";
 import { errorPayload } from "../common/utils/errors";
 import { SessionItem } from "../types/session-item";
+import accessTokenValidatorMiddleware from "../middlewares/access-token/validate-event-payload-middleware";
+import initialiseConfigMiddleware, { configService } from "../middlewares/config/initialise-config-middleware";
 import { AwsClientType, createClient } from "../common/aws-client-factory";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
-import { SSMClient } from "@aws-sdk/client-ssm";
-import { ClientConfigKey, CommonConfigKey } from "../types/config-keys";
-import { BearerAccessTokenFactory } from "../services/bearer-access-token-factory";
-import { errorPayload } from "../types/errors";
-import { Tracer } from "@aws-lambda-powertools/tracer";
-
-const logger = new Logger();
-const metrics = new Metrics();
-const _tracer = new Tracer({ captureHTTPsRequests: false });
+import setGovUkSigningJourneyIdMiddleware from "../middlewares/session/set-gov-uk-signing-journey-id-middleware";
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import getSessionByAuthCodeMiddleware from "../middlewares/session/get-session-by-auth-code-middleware";
+import { logger, metrics, tracer as _tracer } from "../common/utils/power-tool";
+import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { injectLambdaContext } from "@aws-lambda-powertools/logger/lib/middleware/middy";
+import { RequestPayload } from "../types/request_payload";
+import getSessionById from "../middlewares/session/get-session-by-id";
+import errorMiddleware from "../middlewares/error/error-middleware";
 const dynamoDbClient = createClient(AwsClientType.DYNAMO) as DynamoDBDocument;
-const ssmClient = createClient(AwsClientType.SSM) as SSMClient;
-const configService = new ConfigService(ssmClient);
-const initPromise = configService.init([CommonConfigKey.SESSION_TABLE_NAME, CommonConfigKey.SESSION_TTL]);
+
 const ACCESS_TOKEN = "accesstoken";
 
 export class AccessTokenLambda implements LambdaInterface {
@@ -31,30 +30,27 @@ export class AccessTokenLambda implements LambdaInterface {
         private readonly sessionService: SessionService,
         private readonly requestValidator: AccessTokenRequestValidator,
     ) {}
-
-    @logger.injectLambdaContext({ clearState: true })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
     @_tracer.captureLambdaHandler({ captureResponse: false })
-    public async handler(event: APIGatewayProxyEvent, _context: unknown): Promise<APIGatewayProxyResult> {
+    public async handler(event: APIGatewayProxyEvent, _context: Context): Promise<APIGatewayProxyResult> {
         try {
-            await initPromise;
             logger.info("Access Token Lambda triggered");
-
-            const requestPayload = this.requestValidator.validatePayload(event.body);
-            const sessionItem = await this.sessionService.getSessionByAuthorizationCode(requestPayload.code);
-            logger.info("Session found");
+            const eventBody = event.body;
+            const sessionItem = eventBody as unknown as SessionItem;
+            const requestPayload = eventBody as unknown as RequestPayload;
 
             if (!configService.hasClientConfig(sessionItem.clientId)) {
                 await this.initClientConfig(sessionItem.clientId);
             }
             const clientConfig = configService.getClientConfig(sessionItem.clientId);
+
             this.requestValidator.validateTokenRequestToRecord(
                 requestPayload.code,
                 sessionItem,
                 clientConfig.get(ClientConfigKey.JWT_REDIRECT_URI) as string,
             );
-            logger.info("Token request validated");
 
+            logger.info("Token request validated");
             await this.requestValidator.verifyJwtSignature(
                 requestPayload.client_assertion,
                 sessionItem.clientId,
@@ -87,10 +83,23 @@ export class AccessTokenLambda implements LambdaInterface {
         ]);
     }
 }
-
+const jwtVerifierFactory = new JwtVerifierFactory(logger);
+const sessionService = new SessionService(dynamoDbClient, configService);
+const accessTokenValidator = new AccessTokenRequestValidator(jwtVerifierFactory);
 const handlerClass = new AccessTokenLambda(
     new BearerAccessTokenFactory(configService.getBearerAccessTokenTtl()),
-    new SessionService(dynamoDbClient, configService),
-    new AccessTokenRequestValidator(new JwtVerifierFactory(logger)),
+    sessionService,
+    accessTokenValidator,
 );
-export const lambdaHandler = handlerClass.handler.bind(handlerClass);
+export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
+    .use(errorMiddleware(logger, metrics, { metric_name: ACCESS_TOKEN, message: "Access Token Lambda error occurred" }))
+    .use(injectLambdaContext(logger, { clearState: true }))
+    .use(initialiseConfigMiddleware())
+    .use(
+        accessTokenValidatorMiddleware({
+            requestValidator: accessTokenValidator,
+        }),
+    )
+    .use(getSessionByAuthCodeMiddleware({ sessionService: sessionService }))
+    .use(getSessionById({ sessionService: sessionService }))
+    .use(setGovUkSigningJourneyIdMiddleware(logger));

--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -6,6 +6,8 @@ import { SessionService } from "../services/session-service";
 import { ConfigService } from "../common/config/config-service";
 import { AccessTokenRequestValidator } from "../services/token-request-validator";
 import { JwtVerifierFactory } from "../common/security/jwt-verifier";
+import { errorPayload } from "../common/utils/errors";
+import { SessionItem } from "../types/session-item";
 import { AwsClientType, createClient } from "../common/aws-client-factory";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import { SSMClient } from "@aws-sdk/client-ssm";

--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -63,7 +63,6 @@ export class AccessTokenLambda implements LambdaInterface {
 
             logger.info("Access token created");
             metrics.addMetric(ACCESS_TOKEN, MetricUnits.Count, 1);
-            logger.appendKeys({ govuk_signin_journey_id: sessionItem.clientSessionId });
 
             return {
                 statusCode: 200,

--- a/lambdas/src/handlers/authorization-handler.ts
+++ b/lambdas/src/handlers/authorization-handler.ts
@@ -11,7 +11,7 @@ import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import { SSMClient } from "@aws-sdk/client-ssm";
 import { ClientConfigKey, CommonConfigKey } from "../types/config-keys";
 import { Tracer } from "@aws-lambda-powertools/tracer";
-import { errorPayload } from "../types/errors";
+import { errorPayload } from "../common/utils/errors";
 
 const dynamoDbClient = createClient(AwsClientType.DYNAMO) as DynamoDBDocument;
 const ssmClient = createClient(AwsClientType.SSM) as SSMClient;

--- a/lambdas/src/handlers/create-auth-code-handler.ts
+++ b/lambdas/src/handlers/create-auth-code-handler.ts
@@ -8,7 +8,7 @@ import { ConfigService } from "../common/config/config-service";
 import { getSessionId } from "../common/utils/request-utils";
 import { CommonConfigKey } from "../types/config-keys";
 import { Logger } from "@aws-lambda-powertools/logger";
-import { errorPayload } from "../types/errors";
+import { errorPayload } from "../common/utils/errors";
 
 const dynamoDbClient = createClient(AwsClientType.DYNAMO) as DynamoDBDocument;
 const ssmClient = createClient(AwsClientType.SSM) as SSMClient;

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -20,7 +20,7 @@ import { SQSClient } from "@aws-sdk/client-sqs";
 import { AwsClientType, createClient } from "../common/aws-client-factory";
 import { getClientIpAddress } from "../common/utils/request-utils";
 import { KMSClient } from "@aws-sdk/client-kms";
-import { errorPayload } from "../types/errors";
+import { errorPayload } from "../common/utils/errors";
 
 const dynamoDbClient = createClient(AwsClientType.DYNAMO) as DynamoDBDocument;
 const ssmClient = createClient(AwsClientType.SSM) as SSMClient;

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -90,7 +90,7 @@ export class SessionLambda implements LambdaInterface {
 
             metrics.addDimension("issuer", requestBodyClientId);
             metrics.addMetric(SESSION_CREATED_METRIC, MetricUnits.Count, 1);
-            logger.appendKeys({ govuk_signin_journey_id: sessionId });
+            logger.appendKeys({ govuk_signin_journey_id: sessionRequestSummary.clientSessionId });
 
             return {
                 statusCode: 201,

--- a/lambdas/src/middlewares/access-token/validate-event-payload-middleware.ts
+++ b/lambdas/src/middlewares/access-token/validate-event-payload-middleware.ts
@@ -1,0 +1,25 @@
+import { MiddlewareObj, Request } from "@middy/core";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { AccessTokenRequestValidator } from "../../services/token-request-validator";
+
+const defaults = {};
+
+const validateEventPayloadMiddleware = (opts: { requestValidator: AccessTokenRequestValidator }): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
+    const before = async (request: Request) => {
+        const event = request.event as APIGatewayProxyEvent;
+
+        request.event = {
+            body: options.requestValidator.validatePayload(event.body),
+        } as unknown as APIGatewayProxyEvent;
+
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+
+export default validateEventPayloadMiddleware;

--- a/lambdas/src/middlewares/config/initialise-config-middleware.ts
+++ b/lambdas/src/middlewares/config/initialise-config-middleware.ts
@@ -1,0 +1,22 @@
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { MiddlewareObj, Request } from "@middy/core";
+import { AwsClientType, createClient } from "../../common/aws-client-factory";
+import { ConfigService } from "../../common/config/config-service";
+import { CommonConfigKey } from "../../types/config-keys";
+
+const ssmClient = createClient(AwsClientType.SSM) as SSMClient;
+const configService = new ConfigService(ssmClient);
+const initPromise = configService.init([CommonConfigKey.SESSION_TABLE_NAME, CommonConfigKey.SESSION_TTL]);
+const initialiseConfigMiddleware = (): MiddlewareObj => {
+    const before = async (request: Request) => {
+        await initPromise;
+
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+export default initialiseConfigMiddleware;
+export { configService };

--- a/lambdas/src/middlewares/error/error-middleware.ts
+++ b/lambdas/src/middlewares/error/error-middleware.ts
@@ -1,0 +1,27 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { MiddlewareObj, Request } from "@middy/core";
+import { errorPayload } from "../../common/utils/errors";
+
+const defaults = {};
+
+const errorMiddleware = (
+    logger: Logger,
+    metrics: Metrics,
+    opts: { metric_name: string; message: string },
+): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
+    const onError = async (request: Request) => {
+        if (request.response !== undefined) return;
+
+        metrics.addMetric(options.metric_name, MetricUnits.Count, 0);
+        return Promise.resolve(errorPayload(request.error as Error, logger, options.message));
+    };
+
+    return {
+        onError,
+    };
+};
+
+export default errorMiddleware;

--- a/lambdas/src/middlewares/session/get-session-by-auth-code-middleware.ts
+++ b/lambdas/src/middlewares/session/get-session-by-auth-code-middleware.ts
@@ -1,0 +1,28 @@
+import { MiddlewareObj, Request } from "@middy/core";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { SessionService } from "../../services/session-service";
+import { RequestPayload } from "../../types/request_payload";
+
+const defaults = {};
+
+const getSessionByAuthCodeMiddleware = (opts: { sessionService: SessionService }): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
+    const before = async (request: Request) => {
+        const requestPayload = request.event.body as RequestPayload;
+        const sessionItem = await options.sessionService.getSessionByAuthorizationCode(requestPayload.code);
+        request.event = {
+            body: {
+                ...sessionItem,
+                ...requestPayload,
+            },
+        } as unknown as APIGatewayProxyEvent;
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+
+export default getSessionByAuthCodeMiddleware;

--- a/lambdas/src/middlewares/session/get-session-by-id.ts
+++ b/lambdas/src/middlewares/session/get-session-by-id.ts
@@ -1,0 +1,29 @@
+import { MiddlewareObj, Request } from "@middy/core";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { SessionService } from "../../services/session-service";
+import { RequestPayload } from "../../types/request_payload";
+import { SessionItem } from "../../types/session-item";
+
+const defaults = {};
+
+const getSessionById = (opts: { sessionService: SessionService }): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
+    const before = async (request: Request) => {
+        const event_body = request.event.body as SessionItem & RequestPayload;
+        const sessionItem = await options.sessionService.getSession(event_body.sessionId);
+        request.event = {
+            body: {
+                ...sessionItem,
+                ...event_body,
+            },
+        } as unknown as APIGatewayProxyEvent;
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+
+export default getSessionById;

--- a/lambdas/src/middlewares/session/set-gov-uk-signing-journey-id-middleware.ts
+++ b/lambdas/src/middlewares/session/set-gov-uk-signing-journey-id-middleware.ts
@@ -1,0 +1,18 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { MiddlewareObj, Request } from "@middy/core";
+import { SessionItem } from "../../types/session-item";
+
+const setGovUkSigningJourneyIdMiddleware = (logger: Logger): MiddlewareObj => {
+    const before = async (request: Request) => {
+        const { clientSessionId } = request.event.body as SessionItem;
+
+        logger.appendKeys({ govuk_signin_journey_id: clientSessionId });
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+
+export default setGovUkSigningJourneyIdMiddleware;

--- a/lambdas/src/services/auth-request-validator.ts
+++ b/lambdas/src/services/auth-request-validator.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEventQueryStringParameters } from "aws-lambda/trigger/api-gateway-proxy";
-import { SessionValidationError } from "../types/errors";
+import { SessionValidationError } from "../common/utils/errors";
 
 export class AuthorizationRequestValidator {
     validate(

--- a/lambdas/src/services/security/jwe-decrypter.ts
+++ b/lambdas/src/services/security/jwe-decrypter.ts
@@ -1,7 +1,7 @@
 import { base64url } from "jose";
 import { CipherGCMTypes, createDecipheriv, KeyObject } from "crypto";
 import { DecryptCommand, EncryptionAlgorithmSpec, KMSClient } from "@aws-sdk/client-kms";
-import { JweDecrypterError } from "../../types/errors";
+import { JweDecrypterError } from "../../common/utils/errors";
 
 export class JweDecrypter {
     private kmsEncryptionKeyId: string | undefined;

--- a/lambdas/src/services/session-request-validator.ts
+++ b/lambdas/src/services/session-request-validator.ts
@@ -3,7 +3,7 @@ import { JWTPayload } from "jose";
 import { SessionRequestValidationConfig } from "../types/session-request-validation-config";
 import { ClientConfigKey } from "../types/config-keys";
 import { Logger } from "@aws-lambda-powertools/logger";
-import { SessionValidationError } from "../types/errors";
+import { SessionValidationError } from "../common/utils/errors";
 
 export class SessionRequestValidator {
     constructor(private validationConfig: SessionRequestValidationConfig, private jwtVerifier: JwtVerifier) {}

--- a/lambdas/src/services/session-service.ts
+++ b/lambdas/src/services/session-service.ts
@@ -8,7 +8,7 @@ import {
     InvalidAccessTokenError,
     SessionExpiredError,
     SessionNotFoundError,
-} from "../types/errors";
+} from "../common/utils/errors";
 import { SessionRequestSummary } from "../types/session-request-summary";
 import { CommonConfigKey } from "../types/config-keys";
 

--- a/lambdas/src/services/token-request-validator.ts
+++ b/lambdas/src/services/token-request-validator.ts
@@ -1,5 +1,5 @@
 import { SessionItem } from "../types/session-item";
-import { InvalidAccessTokenError, InvalidPayloadError, InvalidRequestError } from "../types/errors";
+import { InvalidAccessTokenError, InvalidPayloadError, InvalidRequestError } from "../common/utils/errors";
 import { RequestPayload } from "../types/request_payload";
 import { JwtVerifier, JwtVerifierFactory } from "../common/security/jwt-verifier";
 import { ClientConfigKey } from "../types/config-keys";

--- a/lambdas/tests/unit/common/utils/request-utils.test.ts
+++ b/lambdas/tests/unit/common/utils/request-utils.test.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyEventHeaders } from "aws-lambda";
 import { getClientIpAddress, getSessionId } from "../../../../src/common/utils/request-utils";
-import { InvalidRequestError } from "../../../../src/types/errors";
+import { InvalidRequestError } from "../../../../src/common/utils/errors";
 
 describe("request-utils", () => {
     describe("getClientIpAddress", () => {

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -1,18 +1,24 @@
-import { JwtVerificationConfig } from "../../../src/types/jwt-verification-config";
-import { AccessTokenLambda } from "../../../src/handlers/access-token-handler";
-import { ConfigService } from "../../../src/common/config/config-service";
-import { AccessTokenRequestValidator } from "../../../src/services/token-request-validator";
-import { SessionService } from "../../../src/services/session-service";
-import { APIGatewayProxyEvent } from "aws-lambda/trigger/api-gateway-proxy";
-import { SSMClient } from "@aws-sdk/client-ssm";
-import { JwtVerifier, JwtVerifierFactory } from "../../../src/common/security/jwt-verifier";
-import { Logger } from "@aws-lambda-powertools/logger";
-import { DynamoDBDocument, QueryCommandInput, QueryCommandOutput } from "@aws-sdk/lib-dynamodb";
-import { SessionItem } from "../../../src/types/session-item";
+import middy from "@middy/core";
 import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
-import { ServerError } from "../../../src/types/errors";
+import { APIGatewayProxyEvent, Context } from "aws-lambda";
+import { AccessTokenLambda } from "../../../src/handlers/access-token-handler";
+import { SessionService } from "../../../src/services/session-service";
+import validateEventPayloadMiddleware from "../../../src/middlewares/access-token/validate-event-payload-middleware";
+import { AccessTokenRequestValidator } from "../../../src/services/token-request-validator";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { injectLambdaContext } from "@aws-lambda-powertools/logger/lib/middleware/middy";
+import { DynamoDBDocument, QueryCommandInput } from "@aws-sdk/lib-dynamodb";
+import { ConfigService } from "../../../src/common/config/config-service";
+import { JwtVerificationConfig } from "../../../src/types/jwt-verification-config";
+import { JwtVerifier, JwtVerifierFactory } from "../../../src/common/security/jwt-verifier";
 import { BearerAccessTokenFactory } from "../../../src/services/bearer-access-token-factory";
-import { JWTPayload } from "jose";
+import { SSMClient } from "@aws-sdk/client-ssm";
+import { InvalidRequestError, ServerError } from "../../../src/common/utils/errors";
+import errorMiddleware from "../../../src/middlewares/error/error-middleware";
+import configurationInitMiddleware from "../../../src/middlewares/config/configuration-init-middleware";
+import getSessionByAuthCodeMiddleware from "../../../src/middlewares/session/get-session-by-auth-code-middleware";
+import getSessionById from "../../../src/middlewares/session/get-session-by-id";
+import setGovUkSigningJourneyIdMiddleware from "../../../src/middlewares/session/set-gov-uk-signing-journey-id-middleware";
 
 jest.mock("../../../src/common/config/config-service");
 jest.mock("../../../src/common/security/jwt-verifier");
@@ -26,203 +32,199 @@ jest.mock("@aws-sdk/lib-dynamodb", () => {
         UpdateCommand: jest.fn(),
     };
 });
+jest.mock("@aws-lambda-powertools/logger/lib/middleware/middy", () => {
+    return {
+        __esModule: true,
+        ...jest.requireActual("@aws-lambda-powertools/logger/lib/middleware/middy"),
+        default: jest.fn(() => ({
+            before: jest.fn(),
+        })),
+    };
+});
 
 describe("access-token-handler.ts", () => {
-    const mockDynamoDbClient = jest.mocked(DynamoDBDocument);
+    let logger: Logger;
+    let metrics: Metrics;
+    let configService: ConfigService;
+    let sessionService: SessionService;
+    let accessTokenLambda: AccessTokenLambda;
+    let lambdaHandler: middy.MiddyfiedHandler;
+    let mockDynamoDbClient: jest.MockedObjectDeep<typeof DynamoDBDocument>;
+    let mockJwtVerifierFactory: jest.MockedObjectDeep<typeof JwtVerifierFactory>;
+    let accessTokenRequestValidator: AccessTokenRequestValidator;
+
+    afterEach(() => jest.resetAllMocks());
 
     beforeEach(() => {
-        jest.resetAllMocks();
-        const impl = () => {
-            const mockPromise = new Promise<unknown>((resolve) => {
-                resolve({ Parameters: [] });
-            });
-            return jest.fn().mockImplementation(() => {
-                return mockPromise;
-            });
-        };
+        const impl = () => jest.fn().mockImplementation(() => Promise.resolve({ Parameters: [] }));
+        mockDynamoDbClient = jest.mocked(DynamoDBDocument);
         mockDynamoDbClient.prototype.send = impl();
         mockDynamoDbClient.prototype.query = impl();
+        mockJwtVerifierFactory = jest.mocked(JwtVerifierFactory);
+
+        logger = new Logger();
+        metrics = new Metrics();
+        configService = new ConfigService(jest.fn() as unknown as SSMClient);
+        sessionService = new SessionService(mockDynamoDbClient.prototype, configService);
+        accessTokenRequestValidator = new AccessTokenRequestValidator(mockJwtVerifierFactory.prototype);
+        accessTokenLambda = new AccessTokenLambda(
+            new BearerAccessTokenFactory(10),
+            sessionService,
+            accessTokenRequestValidator,
+        );
+
+        configService.init = () => Promise.resolve();
+
+        lambdaHandler = middy(accessTokenLambda.handler.bind(accessTokenLambda))
+            .use(
+                errorMiddleware(logger, metrics, {
+                    metric_name: "accesstoken",
+                    message: "Access Token Lambda error occurred",
+                }),
+            )
+            .use(injectLambdaContext(logger, { clearState: true }))
+            .use(configurationInitMiddleware())
+            .use(
+                validateEventPayloadMiddleware({
+                    requestValidator: accessTokenRequestValidator,
+                }),
+            )
+            .use(getSessionByAuthCodeMiddleware({ sessionService: sessionService }))
+            .use(getSessionById({ sessionService: sessionService }))
+            .use(setGovUkSigningJourneyIdMiddleware(logger));
     });
 
     describe("Handler", () => {
-        let accessTokenLambda: AccessTokenLambda;
-        const configService = new ConfigService(jest.fn() as unknown as SSMClient);
-        const logger = new Logger();
         const jwtVerificationConfig: JwtVerificationConfig = {
             publicSigningJwk: "",
             jwtSigningAlgorithm: "",
         };
-        const jwtVerifier = new JwtVerifier(jwtVerificationConfig, logger);
-        const mockJwtVerifierFactory = jest.mocked(JwtVerifierFactory);
-        const mockConfigService = jest.mocked(ConfigService);
-        const accessTokenService = new BearerAccessTokenFactory(10);
-        const sessionService = new SessionService(mockDynamoDbClient.prototype, configService);
-        const accessTokenRequestValidator = new AccessTokenRequestValidator(mockJwtVerifierFactory.prototype);
+        let jwtVerifier: JwtVerifier;
+        let mockMetrics: jest.MockedObjectDeep<typeof Metrics>;
+        let metricsSpy: jest.SpyInstance<unknown, never, unknown>;
+        let mockConfigService: jest.MockedObjectDeep<typeof ConfigService>;
 
-        const mockLogger = jest.mocked(Logger);
-        const mockMetrics = jest.mocked(Metrics);
-        const metricsSpy = jest.spyOn(mockMetrics.prototype, "addMetric");
-
+        const redirectUri = "http://123.abc.com";
+        const code = "123abc";
+        const clientSessionId = "1";
+        const clientConfig = new Map<string, string>();
+        clientConfig.set("code", code);
+        clientConfig.set("redirectUri", redirectUri);
         describe("success paths", () => {
+            const twentyFourthOfFeb2023InMs = 1677249836658;
+            const sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000;
+            const expiry = Math.floor((twentyFourthOfFeb2023InMs + sevenDaysInMilliseconds) / 1000);
+
             beforeEach(() => {
-                jest.resetAllMocks();
-                configService.init = () => Promise.resolve();
-                accessTokenLambda = new AccessTokenLambda(
-                    accessTokenService,
-                    sessionService,
-                    accessTokenRequestValidator,
-                );
+                mockMetrics = jest.mocked(Metrics);
+                metricsSpy = jest.spyOn(mockMetrics.prototype, "addMetric");
+
+                jwtVerifier = new JwtVerifier(jwtVerificationConfig, logger);
+                mockConfigService = jest.mocked(ConfigService);
+
+                jest.spyOn(Date, "now").mockReturnValue(twentyFourthOfFeb2023InMs);
+                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValueOnce(clientConfig);
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<JWTPayload>((resolve) => {
-                        resolve(expect.anything());
-                    }),
-                );
+                jest.spyOn(jwtVerifier, "verify").mockResolvedValueOnce(Promise.resolve(expect.anything()));
             });
+
+            afterEach(() => jest.resetAllMocks());
 
             it("should pass when payload matches session", async () => {
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
-                const clientSessionId = "1";
-
-                const twentyFourthOfFeb2023InMs = 1677249836658;
-                jest.spyOn(Date, "now").mockReturnValue(twentyFourthOfFeb2023InMs);
-                const sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000;
-                const expiry = Math.floor((twentyFourthOfFeb2023InMs + sevenDaysInMilliseconds) / 1000);
-
-                jest.spyOn(mockDynamoDbClient.prototype, "query").mockImplementation(() => {
-                    return Promise.resolve({
-                        Items: [
-                            {
-                                clientSessionId: clientSessionId,
-                                authorizationCode: code,
-                                redirectUri,
-                            },
-                        ],
-                    });
-                });
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
                 const sessionItem = {
-                    Items: [
-                        {
-                            sessionId: code,
-                            authorizationCodeExpiryDate: expiry,
-                            clientId: "1",
-                            clientSessionId: clientSessionId,
-                            redirectUri: redirectUri,
-                            accessToken: "",
-                            accessTokenExpiryDate: expiry,
-                            authorizationCode: code,
-                        } as SessionItem,
-                    ],
-                } as unknown as QueryCommandInput;
-
-                const impl = () => {
-                    const mockPromise = new Promise<unknown>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                    return jest.fn().mockImplementation(() => {
-                        return mockPromise;
-                    });
+                    sessionId: code,
+                    clientSessionId: clientSessionId,
+                    authorizationCode: code,
                 };
-                mockDynamoDbClient.prototype.query = impl();
+                mockDynamoDbClient.prototype.query.mockImplementation(() => Promise.resolve({ Items: [sessionItem] }));
+                mockDynamoDbClient.prototype.send.mockImplementation(() => Promise.resolve({ Item: sessionItem }));
 
-                const event = {
-                    body: {
-                        code,
-                        grant_type: "authorization_code",
-                        redirect_uri: redirectUri,
-                        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        client_assertion: "2",
-                    },
-                } as unknown as APIGatewayProxyEvent;
-                const output = await accessTokenLambda.handler(event, null);
-                expect(output.statusCode).toBe(200);
-                expect(metricsSpy).toHaveBeenCalledWith("accesstoken", MetricUnits.Count, 1);
-            });
-
-            it("should return http 200 if the authorizationCodeExpiryDate is within date", async () => {
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
-
-                const twentyFourthOfFeb2023InMs = 1677249836658;
-                jest.spyOn(Date, "now").mockReturnValue(twentyFourthOfFeb2023InMs);
-                const sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000;
-                const expiry = Math.floor((twentyFourthOfFeb2023InMs + sevenDaysInMilliseconds) / 1000);
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
-                const sessionItem = {
-                    Items: [
-                        {
-                            sessionId: code,
-                            authorizationCodeExpiryDate: expiry,
-                            clientId: "1",
-                            clientSessionId: "1",
-                            redirectUri: redirectUri,
-                            accessToken: "",
-                            accessTokenExpiryDate: expiry,
-                            authorizationCode: code,
-                        } as SessionItem,
-                    ],
-                } as unknown as QueryCommandInput;
-
-                const impl = () => {
-                    const mockPromise = new Promise<unknown>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                    return jest.fn().mockImplementation(() => {
-                        return mockPromise;
-                    });
-                };
-                mockDynamoDbClient.prototype.query = impl();
-
-                const output = await accessTokenLambda.handler(
+                const response = await lambdaHandler(
                     {
                         body: {
-                            code,
-                            grant_type: "authorization_code",
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
                             redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
                             client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                             client_assertion: "2",
                         },
                     } as unknown as APIGatewayProxyEvent,
-                    null,
+                    {} as Context,
                 );
 
-                expect(output.statusCode).toBe(200);
+                expect(response.statusCode).toBe(200);
+                expect(metricsSpy).toHaveBeenCalledWith("accesstoken", MetricUnits.Count, 1);
+            });
+
+            it("should return http 200 if the authorizationCodeExpiryDate is within date", async () => {
+                const sessionItem = {
+                    sessionId: code,
+                    authorizationCodeExpiryDate: expiry,
+                    clientId: "1",
+                    clientSessionId,
+                    redirectUri,
+                    accessToken: "",
+                    accessTokenExpiryDate: expiry,
+                    authorizationCode: code,
+                };
+                mockDynamoDbClient.prototype.query.mockImplementation(() => Promise.resolve({ Items: [sessionItem] }));
+                mockDynamoDbClient.prototype.send.mockImplementation(() => Promise.resolve({ Item: sessionItem }));
+
+                const response = await lambdaHandler(
+                    {
+                        body: {
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
+                            redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
+                            client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                            client_assertion: "2",
+                        },
+                    } as unknown as APIGatewayProxyEvent,
+                    {} as Context,
+                );
+
+                expect(response.statusCode).toBe(200);
                 expect(metricsSpy).toHaveBeenCalledWith("accesstoken", MetricUnits.Count, 1);
             });
         });
 
         describe("Fail paths", () => {
-            const sessionService = new SessionService(mockDynamoDbClient.prototype, configService);
-            const loggerSpy = jest.spyOn(mockLogger.prototype, "error");
+            let mockLogger: jest.MockedObjectDeep<typeof Logger>;
+            let loggerSpy: jest.SpyInstance<unknown, never, unknown>;
+
+            afterEach(() => jest.resetAllMocks());
             beforeEach(() => {
-                jest.resetAllMocks();
-                configService.init = () => Promise.resolve();
-                accessTokenLambda = new AccessTokenLambda(
-                    accessTokenService,
-                    sessionService,
-                    accessTokenRequestValidator,
-                );
+                mockMetrics = jest.mocked(Metrics);
+                mockLogger = jest.mocked(Logger);
+                mockConfigService = jest.mocked(ConfigService);
+                jwtVerifier = new JwtVerifier(jwtVerificationConfig, logger);
+
+                metricsSpy = jest.spyOn(mockMetrics.prototype, "addMetric");
+                loggerSpy = jest.spyOn(mockLogger.prototype, "error");
+
+                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValueOnce(clientConfig);
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
+                jest.spyOn(jwtVerifier, "verify").mockResolvedValueOnce(Promise.resolve(expect.anything()));
             });
 
             it("should fail when no body is passed in the request", async () => {
                 const event = {} as unknown as APIGatewayProxyEvent;
-                const output = await accessTokenLambda.handler(event, null);
-                const body = JSON.parse(output.body);
-                expect(output.statusCode).toBe(400);
-                expect(output.body).not.toBeNull;
+
+                const response = await lambdaHandler(event, {} as Context);
+
+                const body = JSON.parse(response.body);
+                expect(response).toEqual({
+                    statusCode: 400,
+                    body: expect.anything(),
+                });
                 expect(body.message).toContain("missing body");
                 expect(loggerSpy).toHaveBeenCalledWith(
                     "Access Token Lambda error occurred: Invalid request: missing body",
@@ -233,10 +235,12 @@ describe("access-token-handler.ts", () => {
 
             it("should fail when request payload is not valid", async () => {
                 const event = { body: {} } as unknown as APIGatewayProxyEvent;
-                const output = await accessTokenLambda.handler(event, null);
-                const body = JSON.parse(output.body);
-                expect(output.statusCode).toBe(400);
-                expect(output.body).not.toBeNull;
+
+                const response = await lambdaHandler(event, {} as Context);
+
+                const body = JSON.parse(response.body);
+                expect(response.statusCode).toBe(400);
+                expect(response.body).not.toBeNull;
                 expect(body.message).toContain("Invalid request");
                 expect(loggerSpy).toHaveBeenCalledWith(
                     "Access Token Lambda error occurred: Invalid request: Missing redirectUri parameter",
@@ -246,26 +250,26 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should fail when session is not found", async () => {
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<JWTPayload>((resolve) => {
-                        resolve(expect.anything());
-                    }),
+                jest.spyOn(jwtVerifier, "verify").mockReturnValueOnce(Promise.resolve(expect.anything()));
+                const response = await lambdaHandler(
+                    {
+                        body: {
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
+                            redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
+                            client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                            client_assertion: "2",
+                        },
+                    } as unknown as APIGatewayProxyEvent,
+                    {} as Context,
                 );
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
-                const event = {
-                    body: {
-                        code,
-                        grant_type: "authorization_code",
-                        redirect_uri: redirectUri,
-                        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        client_assertion: "2",
-                    },
-                } as unknown as APIGatewayProxyEvent;
-                const output = await accessTokenLambda.handler(event, null);
-                const body = JSON.parse(output.body);
-                expect(output.statusCode).toBe(403);
-                expect(output.body).not.toBeNull;
+                const body = JSON.parse(response.body);
+                expect(response.statusCode).toBe(403);
+                expect(response.body).not.toBeNull;
                 expect(body.message).toContain("Access token expired");
                 expect(loggerSpy).toHaveBeenCalledWith(
                     "Access Token Lambda error occurred: 1026: Access token expired",
@@ -275,49 +279,30 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should fail when authorization code is not found", async () => {
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<JWTPayload>((resolve) => {
-                        resolve(expect.anything());
-                    }),
-                );
+                jest.spyOn(jwtVerifier, "verify").mockReturnValueOnce(Promise.resolve(expect.anything()));
                 const redirectUri = "http://123.abc.com";
                 const code = "DOES_NOT_MATCH";
-                const event = {
-                    body: {
-                        code: code,
-                        grant_type: "authorization_code",
-                        redirect_uri: redirectUri,
-                        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        client_assertion: "2",
-                    },
-                } as unknown as APIGatewayProxyEvent;
-                const mockDynamoDbClientQueryResult: unknown = {
-                    Items: [
-                        {
-                            clientSessionId: "1",
-                            authorizationCode: "123abc",
-                            redirectUri,
+
+                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValueOnce({ Items: [] });
+
+                const output = await lambdaHandler(
+                    {
+                        body: {
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
+                            redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
+                            client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                            client_assertion: "2",
                         },
-                    ],
-                };
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(
-                    mockDynamoDbClientQueryResult as void,
+                    },
+                    {} as Context,
                 );
 
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<JWTPayload>((resolve) => {
-                        resolve(expect.anything());
-                    }),
-                );
-
-                const output = await accessTokenLambda.handler(event, null);
                 const body = JSON.parse(output.body);
-
                 expect(output.statusCode).toBe(403);
                 expect(body.code).toBe(1026);
                 expect(body.message).toContain("Access token expired");
@@ -329,71 +314,34 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should fail when redirect URIs do not match", async () => {
-                const redirectUri = "http://123.abc.com";
                 const badUrl = "http://does-not-match";
-                const code = "DOES_NOT_MATCH";
-
-                const twentyFourthOfFeb2023InMs = 1677249836658;
-                jest.spyOn(Date, "now").mockReturnValue(twentyFourthOfFeb2023InMs);
-                const sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000;
-                const expiry = Math.floor((twentyFourthOfFeb2023InMs + sevenDaysInMilliseconds) / 1000);
-
-                const event = {
-                    body: {
-                        code: code,
-                        grant_type: "authorization_code",
-                        redirect_uri: redirectUri,
-                        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        client_assertion: "2",
-                    },
-                } as unknown as APIGatewayProxyEvent;
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
-                const mockDynamoDbClientQueryResult: unknown = {
-                    Items: [
-                        {
-                            clientSessionId: "1",
-                            authorizationCode: code,
-                            redirectUri,
-                        },
-                    ],
-                };
-
-                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(
-                    mockDynamoDbClientQueryResult as void,
-                );
-
                 const sessionItem = {
-                    Items: [
-                        {
-                            sessionId: code,
-                            authorizationCodeExpiryDate: expiry,
-                            clientId: "1",
-                            clientSessionId: "1",
-                            redirectUri: "http://does-not-match",
-                            accessToken: "",
-                            accessTokenExpiryDate: expiry,
-                            authorizationCode: code,
-                        } as SessionItem,
-                    ],
-                } as unknown as QueryCommandInput;
-
-                const impl = () => {
-                    const mockPromise = new Promise<unknown>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                    return jest.fn().mockImplementation(() => {
-                        return mockPromise;
-                    });
+                    sessionId: code,
+                    clientId: "1",
+                    clientSessionId: "1",
+                    redirectUri: badUrl,
+                    accessToken: "",
+                    authorizationCode: code,
                 };
-                mockDynamoDbClient.prototype.query = impl();
+                mockDynamoDbClient.prototype.query.mockImplementation(() => Promise.resolve({ Items: [sessionItem] }));
+                mockDynamoDbClient.prototype.send.mockImplementation(() => Promise.resolve({ Item: sessionItem }));
 
-                const output = await accessTokenLambda.handler(event, null);
+                const output = await lambdaHandler(
+                    {
+                        body: {
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
+                            redirect_uri: badUrl,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
+                            client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                            client_assertion: "2",
+                        },
+                    },
+                    {} as Context,
+                );
                 const body = JSON.parse(output.body);
                 expect(output.statusCode).toBe(400);
                 expect(body.message).toContain(`redirect uri ${badUrl} does not match`);
@@ -401,70 +349,38 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should error when jwt verify fails", async () => {
-                const redirectUri = "http://123.abc.com";
-
-                const twentyFourthOfFeb2023InMs = 1677249836658;
-                jest.spyOn(Date, "now").mockReturnValue(twentyFourthOfFeb2023InMs);
-                const sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000;
-                const expiry = Math.floor((twentyFourthOfFeb2023InMs + sevenDaysInMilliseconds) / 1000);
-
-                const event = {
-                    body: {
-                        code: "123abc",
-                        grant_type: "authorization_code",
-                        redirect_uri: redirectUri,
-                        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        client_assertion: "2",
-                    },
-                } as unknown as APIGatewayProxyEvent;
-                const mockDynamoDbClientQueryResult: unknown = {
-                    Items: [
-                        {
-                            clientSessionId: "1",
-                            authorizationCode: "123abc",
-                            redirectUri,
-                        },
-                    ],
-                };
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", "123abc");
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
                 const sessionItem = {
-                    Items: [
-                        {
-                            sessionId: "1",
-                            authorizationCodeExpiryDate: expiry,
-                            clientId: "1",
-                            clientSessionId: "1",
-                            redirectUri: redirectUri,
-                            accessToken: "",
-                            accessTokenExpiryDate: expiry,
-                            authorizationCode: "1",
-                        } as SessionItem,
-                    ],
-                } as unknown as QueryCommandInput;
-
-                const impl = () => {
-                    const mockPromise = new Promise<unknown>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                    return jest.fn().mockImplementation(() => {
-                        return mockPromise;
-                    });
+                    sessionId: code,
+                    clientId: "1",
+                    clientSessionId: "1",
+                    redirectUri,
+                    accessToken: "",
+                    authorizationCode: code,
                 };
-                mockDynamoDbClient.prototype.query = impl();
+                mockDynamoDbClient.prototype.query.mockImplementation(() => Promise.resolve({ Items: [sessionItem] }));
+                mockDynamoDbClient.prototype.send.mockImplementation(() => Promise.resolve({ Item: sessionItem }));
 
-                jest.spyOn(mockDynamoDbClient.prototype, "query").mockReturnValue(
-                    mockDynamoDbClientQueryResult as void,
+                jest.spyOn(accessTokenRequestValidator, "verifyJwtSignature").mockRejectedValueOnce(
+                    new InvalidRequestError("JWT signature verification failed"),
                 );
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<null>((resolve) => {
-                        resolve(null);
-                    }),
+
+                const output = await lambdaHandler(
+                    {
+                        body: {
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
+                            redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
+                            client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                            client_assertion: "2",
+                        },
+                    },
+                    {} as Context,
                 );
-                const output = await accessTokenLambda.handler(event, null);
+
                 const body = JSON.parse(output.body);
                 expect(output.statusCode).toBe(400);
                 expect(body.message).toContain(`JWT signature verification failed`);
@@ -476,99 +392,74 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should return http 403 when the session item is invalid", async () => {
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
-
-                jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<JWTPayload>((resolve) => {
-                        resolve(expect.anything());
-                    }),
-                );
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
-                const sessionItem = {
+                const anInValidSessionItem = {
                     Items: [],
-                } as unknown as QueryCommandInput;
-
-                const impl = () => {
-                    const mockPromise = new Promise<unknown>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                    return jest.fn().mockImplementation(() => {
-                        return mockPromise;
-                    });
                 };
-                mockDynamoDbClient.prototype.query = impl();
 
-                const output = await accessTokenLambda.handler(
+                mockDynamoDbClient.prototype.query = jest
+                    .fn()
+                    .mockImplementation(() => Promise.resolve(anInValidSessionItem));
+
+                const response = await lambdaHandler(
                     {
                         body: {
-                            code,
-                            grant_type: "authorization_code",
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
                             redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
                             client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                             client_assertion: "2",
                         },
-                    } as unknown as APIGatewayProxyEvent,
-                    null,
+                    },
+                    {} as Context,
                 );
 
-                expect(output.statusCode).toBe(403);
-                expect(output.body).toContain("Access token expired");
+                expect(response.statusCode).toBe(403);
+                expect(response.body).toContain("Access token expired");
                 expect(metricsSpy).toHaveBeenCalledWith("accesstoken", MetricUnits.Count, 0);
             });
 
             it("should return http 403 if the authorizationCodeExpiryDate has expired", async () => {
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
                 const twentyFourthOfFeb2023InMs = 1677249836658;
-                jest.spyOn(Date, "now").mockReturnValue(twentyFourthOfFeb2023InMs);
+                jest.spyOn(Date, "now").mockReturnValueOnce(twentyFourthOfFeb2023InMs);
                 const sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000;
                 const expiry = Math.floor((twentyFourthOfFeb2023InMs - sevenDaysInMilliseconds) / 1000);
 
-                const sessionItem = {
-                    Items: [
-                        {
-                            sessionId: code,
-                            authorizationCodeExpiryDate: expiry,
-                            clientId: "1",
-                            clientSessionId: "1",
-                            redirectUri: redirectUri,
-                            accessToken: "",
-                            accessTokenExpiryDate: expiry,
-                            authorizationCode: code,
-                        } as SessionItem,
-                    ],
-                } as unknown as QueryCommandOutput;
+                mockDynamoDbClient.prototype.query.mockImplementation(() =>
+                    Promise.resolve({
+                        Items: [
+                            {
+                                sessionId: code,
+                                authorizationCodeExpiryDate: expiry,
+                                clientId: "1",
+                                clientSessionId: "1",
+                                redirectUri: redirectUri,
+                                accessToken: "",
+                                accessTokenExpiryDate: expiry,
+                                authorizationCode: code,
+                            },
+                        ],
+                    }),
+                );
 
-                mockDynamoDbClient.prototype.query.mockImplementation(() => {
-                    return new Promise<JWTPayload>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                });
-
-                const output = await accessTokenLambda.handler(
+                const output = await lambdaHandler(
                     {
                         body: {
-                            code,
-                            grant_type: "authorization_code",
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
                             redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
                             client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                             client_assertion: "2",
                         },
-                    } as unknown as APIGatewayProxyEvent,
-                    null,
+                    },
+                    {} as Context,
                 );
 
                 expect(output.statusCode).toBe(403);
@@ -577,43 +468,31 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should return http 403 if the session has expired", async () => {
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
                 const twentyFourthOfFeb2023InMs = 1677249836658;
                 jest.spyOn(Date, "now").mockReturnValue(twentyFourthOfFeb2023InMs);
                 const sevenDaysInMilliseconds = 7 * 24 * 60 * 60 * 1000;
                 const expiry = Math.floor((twentyFourthOfFeb2023InMs - sevenDaysInMilliseconds) / 1000);
                 const futureExpiry = Math.floor((twentyFourthOfFeb2023InMs + sevenDaysInMilliseconds) / 1000);
 
-                const sessionItem = {
-                    Items: [
-                        {
-                            sessionId: code,
-                            expiryDate: expiry,
-                            authorizationCodeExpiryDate: futureExpiry,
-                            clientId: "1",
-                            clientSessionId: "1",
-                            redirectUri: redirectUri,
-                            accessToken: "",
-                            accessTokenExpiryDate: futureExpiry,
-                            authorizationCode: code,
-                        } as SessionItem,
-                    ],
-                } as unknown as QueryCommandOutput;
+                mockDynamoDbClient.prototype.query.mockImplementation(() =>
+                    Promise.resolve({
+                        Items: [
+                            {
+                                sessionId: code,
+                                expiryDate: expiry,
+                                authorizationCodeExpiryDate: futureExpiry,
+                                clientId: "1",
+                                clientSessionId: "1",
+                                redirectUri: redirectUri,
+                                accessToken: "",
+                                accessTokenExpiryDate: futureExpiry,
+                                authorizationCode: code,
+                            },
+                        ],
+                    }),
+                );
 
-                mockDynamoDbClient.prototype.query.mockImplementation(() => {
-                    return new Promise<JWTPayload>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                });
-
-                const output = await accessTokenLambda.handler(
+                const output = await lambdaHandler(
                     {
                         body: {
                             code,
@@ -622,8 +501,8 @@ describe("access-token-handler.ts", () => {
                             client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                             client_assertion: "2",
                         },
-                    } as unknown as APIGatewayProxyEvent,
-                    null,
+                    },
+                    {} as Context,
                 );
 
                 expect(output.statusCode).toBe(403);
@@ -632,46 +511,32 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should return http 403 when there is more than 1 session item", async () => {
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
+                jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValueOnce(jwtVerifier);
+                jest.spyOn(jwtVerifier, "verify").mockReturnValueOnce(Promise.resolve(expect.anything()));
 
-                jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<JWTPayload>((resolve) => {
-                        resolve(expect.anything());
-                    }),
-                );
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
-
-                const sessionItem = {
+                const twoSessionItems = {
                     Items: [{}, {}],
                 } as unknown as QueryCommandInput;
 
-                const impl = () => {
-                    const mockPromise = new Promise<unknown>((resolve) => {
-                        resolve(sessionItem);
-                    });
-                    return jest.fn().mockImplementation(() => {
-                        return mockPromise;
-                    });
-                };
-                mockDynamoDbClient.prototype.query = impl();
+                mockDynamoDbClient.prototype.query = jest
+                    .fn()
+                    .mockImplementation(() => Promise.resolve(twoSessionItems));
 
-                const output = await accessTokenLambda.handler(
+                const output = await lambdaHandler(
                     {
                         body: {
-                            code,
-                            grant_type: "authorization_code",
+                            authorizationCode: code,
+                            sessionId: code,
+                            clientSessionId,
                             redirect_uri: redirectUri,
+                            clientId: "1",
+                            grant_type: "authorization_code",
+                            code,
                             client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                             client_assertion: "2",
                         },
-                    } as unknown as APIGatewayProxyEvent,
-                    null,
+                    },
+                    {} as Context,
                 );
 
                 expect(output.statusCode).toBe(403);
@@ -680,24 +545,9 @@ describe("access-token-handler.ts", () => {
             });
 
             it("should fail when dynamoDb is not available", async () => {
-                const redirectUri = "http://123.abc.com";
-                const code = "123abc";
-
                 jest.spyOn(mockJwtVerifierFactory.prototype, "create").mockReturnValue(jwtVerifier);
-                jest.spyOn(jwtVerifier, "verify").mockReturnValue(
-                    new Promise<JWTPayload>((resolve) => {
-                        resolve(expect.anything());
-                    }),
-                );
-
-                jest.spyOn(sessionService, "getSessionByAuthorizationCode").mockReturnValue(
-                    Promise.reject(new ServerError()),
-                );
-
-                const clientConfig = new Map<string, string>();
-                clientConfig.set("code", code);
-                clientConfig.set("redirectUri", redirectUri);
-                jest.spyOn(mockConfigService.prototype, "getClientConfig").mockReturnValue(clientConfig);
+                jest.spyOn(jwtVerifier, "verify").mockReturnValue(Promise.resolve(expect.anything()));
+                jest.spyOn(sessionService, "getSessionByAuthorizationCode").mockRejectedValueOnce(new ServerError());
 
                 const event = {
                     body: {
@@ -708,11 +558,11 @@ describe("access-token-handler.ts", () => {
                         client_assertion: "2",
                     },
                 } as unknown as APIGatewayProxyEvent;
-                const output = await accessTokenLambda.handler(event, null);
+                const output = await lambdaHandler(event, {} as Context);
                 expect(output.statusCode).toBe(500);
                 expect(loggerSpy).toHaveBeenCalledWith(
                     "Access Token Lambda error occurred: Server error",
-                    Error("Server error"),
+                    new ServerError(),
                 );
                 expect(metricsSpy).toHaveBeenCalledWith("accesstoken", MetricUnits.Count, 0);
             });

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -15,7 +15,7 @@ import { BearerAccessTokenFactory } from "../../../src/services/bearer-access-to
 import { SSMClient } from "@aws-sdk/client-ssm";
 import { InvalidRequestError, ServerError } from "../../../src/common/utils/errors";
 import errorMiddleware from "../../../src/middlewares/error/error-middleware";
-import configurationInitMiddleware from "../../../src/middlewares/config/configuration-init-middleware";
+import initialiseConfigMiddleware from "../../../src/middlewares/config/initialise-config-middleware";
 import getSessionByAuthCodeMiddleware from "../../../src/middlewares/session/get-session-by-auth-code-middleware";
 import getSessionById from "../../../src/middlewares/session/get-session-by-id";
 import setGovUkSigningJourneyIdMiddleware from "../../../src/middlewares/session/set-gov-uk-signing-journey-id-middleware";
@@ -83,7 +83,7 @@ describe("access-token-handler.ts", () => {
                 }),
             )
             .use(injectLambdaContext(logger, { clearState: true }))
-            .use(configurationInitMiddleware())
+            .use(initialiseConfigMiddleware())
             .use(
                 validateEventPayloadMiddleware({
                     requestValidator: accessTokenRequestValidator,

--- a/lambdas/tests/unit/handlers/authorization-handler.test.ts
+++ b/lambdas/tests/unit/handlers/authorization-handler.test.ts
@@ -17,7 +17,7 @@ import {
     ServerError,
     SessionNotFoundError,
     SessionValidationError,
-} from "../../../src/types/errors";
+} from "../../../src/common/utils/errors";
 
 jest.mock("../../../src/common/config/config-service");
 jest.mock("@aws-lambda-powertools/metrics");

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -14,7 +14,7 @@ import {
     SessionRequestValidatorFactory,
 } from "../../../src/services/session-request-validator";
 import { SessionService } from "../../../src/services/session-service";
-import { GenericServerError, SessionValidationError } from "../../../src/types/errors";
+import { GenericServerError, SessionValidationError } from "../../../src/common/utils/errors";
 import { JWTPayload } from "jose";
 
 jest.mock("@aws-sdk/lib-dynamodb");

--- a/lambdas/tests/unit/services/session-service.test.ts
+++ b/lambdas/tests/unit/services/session-service.test.ts
@@ -2,7 +2,7 @@ import { SessionService } from "../../../src/services/session-service";
 import { ConfigService } from "../../../src/common/config/config-service";
 import { SSMClient } from "@aws-sdk/client-ssm";
 import { DynamoDBDocument, GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
-import { InvalidAccessTokenError, SessionNotFoundError } from "../../../src/types/errors";
+import { InvalidAccessTokenError, SessionNotFoundError } from "../../../src/common/utils/errors";
 import { SessionItem } from "../../../src/types/session-item";
 
 jest.mock("@aws-sdk/lib-dynamodb", () => {

--- a/lambdas/tests/unit/services/token-request-validator.test.ts
+++ b/lambdas/tests/unit/services/token-request-validator.test.ts
@@ -1,7 +1,7 @@
 import { AccessTokenRequestValidator } from "../../../src/services/token-request-validator";
 import { JwtVerifierFactory } from "../../../src/common/security/jwt-verifier";
 import { SessionItem } from "../../../src/types/session-item";
-import { InvalidPayloadError } from "../../../src/types/errors";
+import { InvalidPayloadError } from "../../../src/common/utils/errors";
 
 describe("token-request-validator.ts", () => {
     let accessTokenRequestValidator: AccessTokenRequestValidator;


### PR DESCRIPTION
## Proposed changes

This is the 1st of a few more PR'S to go that uses middy as a way to ensure that `govuk_signin_journey_id` sticks around, when using `logger.appendkeys` since middy is middleware a series of middlewares are constructed to get the persisted id

This work uncovered a few gaps as well:

- the actual value used for the id was wrong is the session lambda, value used should be `clientSessionId` which come from  jwtPayload key of the name `govuk_signin_journey_id`
- Also we do not have the value require when retrieving the sessionItem via the `getSessionByAuthCode`
 this is b'cos we a using a global index which exposes only (sessionId, redirectUri, clientId) ideally we want to expose the clientSessionId as well to get the `govuk_signin_journey_id` updating the global index is not straight forward so this should be done as separate ticket. For now a second trip is needed to retreive the full SessionItem object

### What changed

The use of several middlewares, with the aim of ensuring journey id is available it the logs

### Why did it change

see https://govukverify.atlassian.net/browse/OJ-1413
