### PR TITLE
Oj-1413: use middy in access session lambda

### DIFF
--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -3,7 +3,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda
 import { SessionService } from "../services/session-service";
 import { AccessTokenRequestValidator } from "../services/token-request-validator";
 import { JwtVerifierFactory } from "../common/security/jwt-verifier";
-import { ClientConfigKey } from "../types/config-keys";
+import { ClientConfigKey, CommonConfigKey } from "../types/config-keys";
 import { BearerAccessTokenFactory } from "../services/bearer-access-token-factory";
 import { errorPayload } from "../common/utils/errors";
 import { SessionItem } from "../types/session-item";
@@ -93,7 +93,7 @@ const handlerClass = new AccessTokenLambda(
 export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
     .use(errorMiddleware(logger, metrics, { metric_name: ACCESS_TOKEN, message: "Access Token Lambda error occurred" }))
     .use(injectLambdaContext(logger, { clearState: true }))
-    .use(initialiseConfigMiddleware())
+    .use(initialiseConfigMiddleware({ config_keys : [CommonConfigKey.SESSION_TABLE_NAME, CommonConfigKey.SESSION_TTL]}))
     .use(
         accessTokenValidatorMiddleware({
             requestValidator: accessTokenValidator,

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -45,6 +45,7 @@ export class SessionLambda implements LambdaInterface {
             const deserialisedRequestBody = JSON.parse(event.body as string);
             logger.info("Session lambda triggered");
 
+            console.dir(deserialisedRequestBody);
             const requestBodyClientId = deserialisedRequestBody.client_id;
             const clientIpAddress = getClientIpAddress(event);
 
@@ -55,10 +56,10 @@ export class SessionLambda implements LambdaInterface {
             const criClientConfig = configService.getClientConfig(requestBodyClientId) as Map<string, string>;
             const sessionRequestValidator = this.sessionRequestValidatorFactory.create(criClientConfig);
 
-            const decryptedJwt = await this.jweDecrypter.decryptJwe(deserialisedRequestBody.request);
-            logger.info("JWE decrypted");
+            //const decryptedJwt = //await this.jweDecrypter.decryptJwe(deserialisedRequestBody.request);
+            //logger.info("JWE decrypted");
 
-            const jwtPayload = await sessionRequestValidator.validateJwt(decryptedJwt, requestBodyClientId);
+            const jwtPayload = await sessionRequestValidator.validateJwt(deserialisedRequestBody as Buffer, requestBodyClientId);
             logger.info("JWT validated");
 
             const sessionRequestSummary = this.createSessionRequestSummary(jwtPayload, clientIpAddress);
@@ -148,7 +149,7 @@ export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
     CommonConfigKey.PERSON_IDENTITY_TABLE_NAME,
     CommonConfigKey.DECRYPTION_KEY_ID,
     CommonConfigKey.VC_ISSUER,
-]}))
+]}));
 
 
 

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -1,8 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { LambdaInterface } from "@aws-lambda-powertools/commons";
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
-import { Tracer } from "@aws-lambda-powertools/tracer";
-import { Logger } from "@aws-lambda-powertools/logger";
+import { MetricUnits } from "@aws-lambda-powertools/metrics";
 import { ConfigService } from "../common/config/config-service";
 import { ClientConfigKey, CommonConfigKey } from "../types/config-keys";
 import { SessionService } from "../services/session-service";
@@ -21,15 +19,13 @@ import { AwsClientType, createClient } from "../common/aws-client-factory";
 import { getClientIpAddress } from "../common/utils/request-utils";
 import { KMSClient } from "@aws-sdk/client-kms";
 import { errorPayload } from "../common/utils/errors";
+import { logger, metrics, tracer as _tracer } from "../common/utils/power-tool";
 
 const dynamoDbClient = createClient(AwsClientType.DYNAMO) as DynamoDBDocument;
 const ssmClient = createClient(AwsClientType.SSM) as SSMClient;
 const sqsClient = createClient(AwsClientType.SQS) as SQSClient;
 const kmsClient = createClient(AwsClientType.KMS) as KMSClient;
 
-const logger = new Logger();
-const metrics = new Metrics();
-const _tracer = new Tracer({ captureHTTPsRequests: false });
 const configService = new ConfigService(ssmClient);
 const configInitPromise = configService.init([
     CommonConfigKey.SESSION_TABLE_NAME,

--- a/lambdas/src/middlewares/access-token/validate-event-payload-middleware.ts
+++ b/lambdas/src/middlewares/access-token/validate-event-payload-middleware.ts
@@ -11,6 +11,7 @@ const validateEventPayloadMiddleware = (opts: { requestValidator: AccessTokenReq
         const event = request.event as APIGatewayProxyEvent;
 
         request.event = {
+            ...request.event,
             body: options.requestValidator.validatePayload(event.body),
         } as unknown as APIGatewayProxyEvent;
 

--- a/lambdas/src/middlewares/config/initialise-client-config-middleware.ts
+++ b/lambdas/src/middlewares/config/initialise-client-config-middleware.ts
@@ -1,0 +1,27 @@
+import { MiddlewareObj, Request } from "@middy/core";
+import { ConfigService } from "../../common/config/config-service";
+import { ClientConfigKey } from "../../types/config-keys";
+
+const defaults = {};
+
+const initialiseClientConfigMiddleware = (opts: {
+    configService: ConfigService;
+    client_config_keys: ClientConfigKey[];
+}): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
+    const before = async (request: Request) => {
+        const event_body = request.event.body;
+        if (!options.configService.hasClientConfig(event_body.clientId)) {
+            await options.configService.initClientConfig(event_body.clientId, options.client_config_keys);
+        }
+
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+
+export default initialiseClientConfigMiddleware;

--- a/lambdas/src/middlewares/config/initialise-config-middleware.ts
+++ b/lambdas/src/middlewares/config/initialise-config-middleware.ts
@@ -1,18 +1,17 @@
-import { SSMClient } from "@aws-sdk/client-ssm";
 import { MiddlewareObj, Request } from "@middy/core";
-import { AwsClientType, createClient } from "../../common/aws-client-factory";
 import { ConfigService } from "../../common/config/config-service";
 import { CommonConfigKey } from "../../types/config-keys";
 
 const defaults = {};
 
-const ssmClient = createClient(AwsClientType.SSM) as SSMClient;
-const configService = new ConfigService(ssmClient);
-const initialiseConfigMiddleware = (opts: { config_keys: Array<CommonConfigKey>}): MiddlewareObj => {
+const initialiseConfigMiddleware = (opts: {
+    configService: ConfigService;
+    config_keys: CommonConfigKey[];
+}): MiddlewareObj => {
     const options = { ...defaults, ...opts };
 
     const before = async (request: Request) => {
-        await configService.init(options.config_keys);
+        await options.configService.init(options.config_keys);
 
         await request.event;
     };
@@ -22,4 +21,3 @@ const initialiseConfigMiddleware = (opts: { config_keys: Array<CommonConfigKey>}
     };
 };
 export default initialiseConfigMiddleware;
-export { configService };

--- a/lambdas/src/middlewares/config/initialise-config-middleware.ts
+++ b/lambdas/src/middlewares/config/initialise-config-middleware.ts
@@ -4,12 +4,15 @@ import { AwsClientType, createClient } from "../../common/aws-client-factory";
 import { ConfigService } from "../../common/config/config-service";
 import { CommonConfigKey } from "../../types/config-keys";
 
+const defaults = {};
+
 const ssmClient = createClient(AwsClientType.SSM) as SSMClient;
 const configService = new ConfigService(ssmClient);
-const initPromise = configService.init([CommonConfigKey.SESSION_TABLE_NAME, CommonConfigKey.SESSION_TTL]);
-const initialiseConfigMiddleware = (): MiddlewareObj => {
+const initialiseConfigMiddleware = (opts: { config_keys: Array<CommonConfigKey>}): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
     const before = async (request: Request) => {
-        await initPromise;
+        await configService.init(options.config_keys);
 
         await request.event;
     };

--- a/lambdas/src/middlewares/jwt/decrypt-jwe-middleware.ts
+++ b/lambdas/src/middlewares/jwt/decrypt-jwe-middleware.ts
@@ -1,0 +1,29 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { MiddlewareObj, Request } from "@middy/core";
+import { JweDecrypter } from "../../services/security/jwe-decrypter";
+
+const defaults = {};
+
+const decryptJweMiddleware = (logger: Logger, opts: { jweDecrypter: JweDecrypter }): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
+    const before = async (request: Request) => {
+        const { client_id: clientId, request: input } = JSON.parse(request.event.body);
+        const jwePayload = { decryptedJwe: await options.jweDecrypter.decryptJwe(input) };
+        request.event = {
+            ...request.event,
+            body: {
+                ...jwePayload,
+                clientId,
+            },
+        };
+        logger.info("JWE decrypted");
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+
+export default decryptJweMiddleware;

--- a/lambdas/src/middlewares/jwt/validate-jwt-middleware.ts
+++ b/lambdas/src/middlewares/jwt/validate-jwt-middleware.ts
@@ -1,0 +1,38 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { MiddlewareObj, Request } from "@middy/core";
+import { ConfigService } from "../../common/config/config-service";
+import { SessionRequestValidatorFactory } from "../../services/session-request-validator";
+import { JweRequest } from "../../types/jwe-request";
+
+const defaults = {};
+
+const validateJwtMiddleware = (
+    logger: Logger,
+    opts: { configService: ConfigService; jwtValidatorFactory: SessionRequestValidatorFactory },
+): MiddlewareObj => {
+    const options = { ...defaults, ...opts };
+
+    const before = async (request: Request) => {
+        const { clientId, decryptedJwe } = request.event.body as JweRequest;
+
+        const criClientConfig = options.configService.getClientConfig(clientId) as Map<string, string>;
+        const jwtValidator = options.jwtValidatorFactory.create(criClientConfig);
+        const jwtPayload = await jwtValidator.validateJwt(decryptedJwe, clientId);
+        const clientSessionId = jwtPayload["govuk_signin_journey_id"] as string;
+        request.event = {
+            ...request.event,
+            body: {
+                clientSessionId,
+                ...jwtPayload,
+            },
+        };
+        logger.info("JWT validated");
+        await request.event;
+    };
+
+    return {
+        before,
+    };
+};
+
+export default validateJwtMiddleware;

--- a/lambdas/src/middlewares/session/get-session-by-auth-code-middleware.ts
+++ b/lambdas/src/middlewares/session/get-session-by-auth-code-middleware.ts
@@ -12,6 +12,7 @@ const getSessionByAuthCodeMiddleware = (opts: { sessionService: SessionService }
         const requestPayload = request.event.body as RequestPayload;
         const sessionItem = await options.sessionService.getSessionByAuthorizationCode(requestPayload.code);
         request.event = {
+            ...request.event,
             body: {
                 ...sessionItem,
                 ...requestPayload,

--- a/lambdas/src/middlewares/session/get-session-by-id.ts
+++ b/lambdas/src/middlewares/session/get-session-by-id.ts
@@ -1,5 +1,4 @@
 import { MiddlewareObj, Request } from "@middy/core";
-import { APIGatewayProxyEvent } from "aws-lambda";
 import { SessionService } from "../../services/session-service";
 import { RequestPayload } from "../../types/request_payload";
 import { SessionItem } from "../../types/session-item";
@@ -13,11 +12,12 @@ const getSessionById = (opts: { sessionService: SessionService }): MiddlewareObj
         const event_body = request.event.body as SessionItem & RequestPayload;
         const sessionItem = await options.sessionService.getSession(event_body.sessionId);
         request.event = {
+            ...request.event,
             body: {
                 ...sessionItem,
                 ...event_body,
             },
-        } as unknown as APIGatewayProxyEvent;
+        };
         await request.event;
     };
 

--- a/lambdas/src/middlewares/session/set-gov-uk-signing-journey-id-middleware.ts
+++ b/lambdas/src/middlewares/session/set-gov-uk-signing-journey-id-middleware.ts
@@ -1,10 +1,9 @@
 import { Logger } from "@aws-lambda-powertools/logger";
 import { MiddlewareObj, Request } from "@middy/core";
-import { SessionItem } from "../../types/session-item";
 
 const setGovUkSigningJourneyIdMiddleware = (logger: Logger): MiddlewareObj => {
     const before = async (request: Request) => {
-        const { clientSessionId } = request.event.body as SessionItem;
+        const { clientSessionId } = request.event.body;
 
         logger.appendKeys({ govuk_signin_journey_id: clientSessionId });
         await request.event;

--- a/lambdas/src/types/jwe-request.ts
+++ b/lambdas/src/types/jwe-request.ts
@@ -1,0 +1,4 @@
+export interface JweRequest {
+    clientId: string;
+    decryptedJwe: Buffer;
+}

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -85,7 +85,12 @@ describe("access-token-handler.ts", () => {
                 }),
             )
             .use(injectLambdaContext(logger, { clearState: true }))
-            .use(initialiseConfigMiddleware({ config_keys : [CommonConfigKey.SESSION_TABLE_NAME, CommonConfigKey.SESSION_TTL]}))
+            .use(
+                initialiseConfigMiddleware({
+                    configService: configService,
+                    config_keys: [CommonConfigKey.SESSION_TABLE_NAME, CommonConfigKey.SESSION_TTL],
+                }),
+            )
             .use(
                 validateEventPayloadMiddleware({
                     requestValidator: accessTokenRequestValidator,

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -1,4 +1,5 @@
 import middy from "@middy/core";
+
 import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { APIGatewayProxyEvent, Context } from "aws-lambda";
 import { AccessTokenLambda } from "../../../src/handlers/access-token-handler";
@@ -19,6 +20,7 @@ import initialiseConfigMiddleware from "../../../src/middlewares/config/initiali
 import getSessionByAuthCodeMiddleware from "../../../src/middlewares/session/get-session-by-auth-code-middleware";
 import getSessionById from "../../../src/middlewares/session/get-session-by-id";
 import setGovUkSigningJourneyIdMiddleware from "../../../src/middlewares/session/set-gov-uk-signing-journey-id-middleware";
+import { CommonConfigKey } from "../../../src/types/config-keys";
 
 jest.mock("../../../src/common/config/config-service");
 jest.mock("../../../src/common/security/jwt-verifier");
@@ -83,7 +85,7 @@ describe("access-token-handler.ts", () => {
                 }),
             )
             .use(injectLambdaContext(logger, { clearState: true }))
-            .use(initialiseConfigMiddleware())
+            .use(initialiseConfigMiddleware({ config_keys : [CommonConfigKey.SESSION_TABLE_NAME, CommonConfigKey.SESSION_TTL]}))
             .use(
                 validateEventPayloadMiddleware({
                     requestValidator: accessTokenRequestValidator,

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -1,7 +1,9 @@
-import { Logger } from "@aws-lambda-powertools/logger";
+import middy from "@middy/core";
+
+import { injectLambdaContext, Logger } from "@aws-lambda-powertools/logger";
 import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
-import { APIGatewayProxyEvent, APIGatewayProxyEventHeaders } from "aws-lambda";
-import { ClientConfigKey } from "../../../src/types/config-keys";
+import { APIGatewayProxyEvent, APIGatewayProxyEventHeaders, Context } from "aws-lambda";
+import { ClientConfigKey, CommonConfigKey } from "../../../src/types/config-keys";
 import { ConfigService } from "../../../src/common/config/config-service";
 import { AuditService } from "../../../src/common/services/audit-service";
 import { AuditEventType } from "../../../src/types/audit-event";
@@ -16,6 +18,8 @@ import {
 import { SessionService } from "../../../src/services/session-service";
 import { GenericServerError, SessionValidationError } from "../../../src/common/utils/errors";
 import { JWTPayload } from "jose";
+import initialiseConfigMiddleware from "../../../src/middlewares/config/initialise-config-middleware";
+import errorMiddleware from "../../../src/middlewares/error/error-middleware";
 
 jest.mock("@aws-sdk/lib-dynamodb");
 jest.mock("@aws-sdk/client-ssm");
@@ -24,15 +28,17 @@ jest.mock("@aws-sdk/client-kms");
 jest.mock("@aws-lambda-powertools/metrics");
 jest.mock("../../../src/common/config/config-service");
 jest.mock("../../../src/services/session-request-validator");
+const SESSION_CREATED_METRIC = "session_created";
 
 describe("SessionLambda", () => {
     let sessionLambda: SessionLambda;
+    let lambdaHandler: middy.MiddyfiedHandler;
 
+    const logger = jest.mocked(Logger);
+    const metrics = jest.mocked(Metrics);
     const personIdentityService = jest.mocked(PersonIdentityService);
     const jweDecrypter = jest.mocked(JweDecrypter);
     const auditService = jest.mocked(AuditService);
-    const logger = jest.mocked(Logger);
-    const metrics = jest.mocked(Metrics);
     const configService = jest.mocked(ConfigService);
     const sessionService = jest.mocked(SessionService);
     const sessionRequestValidator = jest.mocked(SessionRequestValidator);
@@ -105,7 +111,17 @@ describe("SessionLambda", () => {
             jweDecrypter.prototype,
             auditService.prototype,
         );
-
+        lambdaHandler = middy(sessionLambda.handler.bind(sessionLambda))
+        .use(errorMiddleware(logger.prototype, metrics.prototype, { metric_name: SESSION_CREATED_METRIC, message: "Session Lambda error occurred" }))
+        .use(injectLambdaContext(logger.prototype, { clearState: true }))
+        .use(initialiseConfigMiddleware({ config_keys: [
+            CommonConfigKey.SESSION_TABLE_NAME,
+            CommonConfigKey.SESSION_TTL,
+            CommonConfigKey.PERSON_IDENTITY_TABLE_NAME,
+            CommonConfigKey.DECRYPTION_KEY_ID,
+            CommonConfigKey.VC_ISSUER,
+        ]}));
+        
         jest.spyOn(jweDecrypter.prototype, "decryptJwe").mockResolvedValue(Buffer.from("test-data"));
         jest.spyOn(personIdentityService.prototype, "savePersonIdentity").mockImplementation();
         jest.spyOn(auditService.prototype, "sendAuditEvent").mockImplementation();
@@ -133,7 +149,7 @@ describe("SessionLambda", () => {
     });
 
     it("should decrypt the JWE", async () => {
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         expect(jweDecrypter.prototype.decryptJwe).toHaveBeenCalledWith("jwe-request");
     });
@@ -145,7 +161,7 @@ describe("SessionLambda", () => {
                 "Invalid request: JWT validation/verification failed: failure",
             ),
         );
-        const result = await sessionLambda.handler(mockEvent, {});
+        const result = await lambdaHandler(mockEvent, {} as Context);
 
         expect(result.statusCode).toBe(400);
         expect(result.body).toContain("1019: Session Validation Exception");
@@ -159,7 +175,7 @@ describe("SessionLambda", () => {
     it("should initialise the client config if unavailable", async () => {
         jest.spyOn(configService.prototype, "hasClientConfig").mockReturnValue(false);
 
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         expect(configService.prototype.initClientConfig).toHaveBeenCalledWith("test-client-id", [
             ClientConfigKey.JWT_AUDIENCE,
@@ -171,13 +187,13 @@ describe("SessionLambda", () => {
     });
 
     it("should get the client config", async () => {
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         expect(configService.prototype.getClientConfig).toHaveBeenCalledWith("test-client-id");
     });
 
     it("should validate the JWT", async () => {
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         expect(sessionRequestValidatorFactory.prototype.create).toHaveBeenCalledWith(mockMap);
         expect(sessionRequestValidator.prototype.validateJwt).toHaveBeenCalledWith(
@@ -194,14 +210,14 @@ describe("SessionLambda", () => {
             ),
         );
 
-        const result = await sessionLambda.handler(mockEvent, {});
+        const result = await lambdaHandler(mockEvent, {} as Context);
         expect(result.statusCode).toBe(400);
         expect(result.body).toContain("1019: Session Validation Exception");
     });
 
     it("should save the session details", async () => {
         const spy = jest.spyOn(sessionService.prototype, "saveSession");
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         const expectedSessionRequestSummary = {
             clientId: "test-jwt-client-id",
@@ -217,7 +233,7 @@ describe("SessionLambda", () => {
 
     it("should save the personal identity information", async () => {
         const spy = jest.spyOn(personIdentityService.prototype, "savePersonIdentity");
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         expect(spy).toHaveBeenCalledWith(mockPerson, "test-session-id");
     });
@@ -237,14 +253,14 @@ describe("SessionLambda", () => {
         );
 
         const spy = jest.spyOn(personIdentityService.prototype, "savePersonIdentity");
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         expect(spy).not.toHaveBeenCalled();
     });
 
     it("should send the audit event", async () => {
         const spy = jest.spyOn(auditService.prototype, "sendAuditEvent");
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
 
         expect(spy).toHaveBeenCalledWith(AuditEventType.START, {
             clientIpAddress: "test-client-ip-address",
@@ -260,13 +276,13 @@ describe("SessionLambda", () => {
     it("should successfully register the metrics", async () => {
         const dimensionSpy = jest.spyOn(metrics.prototype, "addDimension");
         const metricSpy = jest.spyOn(metrics.prototype, "addMetric");
-        await sessionLambda.handler(mockEvent, {});
+        await lambdaHandler(mockEvent, {} as Context);
         expect(dimensionSpy).toHaveBeenCalledWith("issuer", "test-client-id");
         expect(metricSpy).toHaveBeenCalledWith("session_created", MetricUnits.Count, 1);
     });
 
     it("should successfully start the session", async () => {
-        const result = await sessionLambda.handler(mockEvent, {});
+        const result = await lambdaHandler(mockEvent, {} as Context);
         expect(JSON.parse(result.body)).toEqual({
             session_id: "test-session-id",
             state: "test-state",
@@ -278,7 +294,7 @@ describe("SessionLambda", () => {
     it("should catch and return any errors", async () => {
         jest.spyOn(sessionRequestValidator.prototype, "validateJwt").mockRejectedValue(new GenericServerError());
 
-        const result = await sessionLambda.handler(mockEvent, {});
+        const result = await lambdaHandler(mockEvent, {} as Context);
         expect(errorSpy).toHaveBeenCalledWith(
             "Session Lambda error occurred: 1025: Request failed due to a server error",
             new GenericServerError(),


### PR DESCRIPTION
## Proposed changes

This is the 2nd PR that uses middy as a way to ensure that `govuk_signin_journey_id` sticks around, when using `logger.appendkeys` since middy is middleware a series of middlewares are constructed to get the persisted id
see: https://github.com/alphagov/di-ipv-cri-common-lambdas/pull/190  for the 1st PR

Things to note here:

Introduced `initialiseClientConfigMiddleware` which uses the client Id to retrieve configuration for both the session and access token hander

/{aws-common-stackname}/clients/ipv-core-stub/jwtAuthentication/redirectUri 
/{aws-common-stackname}/clients/ipv-core-stub/jwtAuthentication/publicSigningJwkBase64
/{aws-common-stackname}/clients/ipv-core-stub/jwtAuthentication/issuer
/{aws-common-stackname}/clients/ipv-core-stub/jwtAuthentication/authenticationAlg 
/{aws-common-stackname}/clients/ipv-core-stub/jwtAuthentication/audience

in the case of session handler the client id is obtained from the incomming request as the `client_id` decryptJweMiddleware

 `const { client_id: clientId, request: input } = JSON.parse(request.event.body);`

therefore transforms this to the form `clientId`  this is because the access token handler retrieves the clientId from the `SessionItem` in the form `clientId`

### What changed

The use of several middlewares, with the aim of ensuring journey id is available it the logs
- decryptJweMiddleware - decrypts the jwe request and also makes the client_id accessible as clientId in subsequent middleware
- validateJwtMiddleware - Validates jwtpayload ensures the the clientId from the request matches the one the decrypted jwe request
- JweRequest - intermediary type to hold the clientId, decryptedJwe

### Why did it change

see https://govukverify.atlassian.net/browse/OJ-1413
