### PR TITLE
BAU: Allow running Integration test on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ If you have not installed `pre-commit` then please do so [here](https://pre-comm
 
 `STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" gradle integration-tests:cucumber
 `
+You can run against local host as follows:
+
+Run the either KBV or ADDRESS front-end and ensure the you start the stub as well
+
+`STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" DEFAULT_REDIRECT_URI="http://localhost:8085/callback" gradle integration-tests:cucumber
+`

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static gov.uk.di.ipv.cri.common.api.util.IpvCoreStubUtil.sendCreateAuthCodeRequest;
@@ -28,7 +29,8 @@ public class APISteps {
     public static String DEV_ACCESS_TOKEN_URI;
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final String DEFAULT_REDIRECT_URI =
-            "https://di-ipv-core-stub.london.cloudapps.digital/callback";
+            Optional.ofNullable(System.getenv("DEFAULT_REDIRECT_URI"))
+                    .orElse("https://di-ipv-core-stub.london.cloudapps.digital/callback");
     private static final String DEFAULT_CLIENT_ID = "ipv-core-stub";
     private String currentAuthorizationCode;
     private String sessionRequestBody;

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -17,7 +17,8 @@ import static gov.uk.di.ipv.cri.common.api.stepDefinitions.APISteps.DEV_ACCESS_T
 
 public class IpvCoreStubUtil {
 
-    private static final String ADDRESS_CRI_DEV = "address-cri-dev";
+    private static final String CRI_DEV =
+            Optional.ofNullable(System.getenv("CRI_DEV")).orElse("address-cri-dev");
     private static final String API_GATEWAY_ID_PRIVATE = "API_GATEWAY_ID_PRIVATE";
 
     public static String getPrivateApiEndpoint() {
@@ -39,7 +40,7 @@ public class IpvCoreStubUtil {
                         .uri(
                                 new URIBuilder(getIPVCoreStubURL())
                                         .setPath("backend/generateInitialClaimsSet")
-                                        .addParameter("cri", ADDRESS_CRI_DEV)
+                                        .addParameter("cri", CRI_DEV)
                                         .addParameter(
                                                 "rowNumber", String.valueOf(userDataRowNumber))
                                         .build())
@@ -89,7 +90,7 @@ public class IpvCoreStubUtil {
         var uri =
                 new URIBuilder(getIPVCoreStubURL())
                         .setPath("backend/createSessionRequest")
-                        .addParameter("cri", ADDRESS_CRI_DEV)
+                        .addParameter("cri", CRI_DEV)
                         .build();
 
         HttpRequest request =
@@ -182,7 +183,7 @@ public class IpvCoreStubUtil {
         var url =
                 new URIBuilder(baseUrl)
                         .setPath("backend/createTokenRequestPrivateKeyJWT")
-                        .addParameter("cri", ADDRESS_CRI_DEV)
+                        .addParameter("cri", CRI_DEV)
                         .addParameter("authorization_code", authorizationCode)
                         .build();
 


### PR DESCRIPTION
This PR allow running integration test against localhost:8085 rather than the stub URL, this useful checking the if test pass local. Also introduced enviroment variable CRI_DEV so that the jwe can be produced with the expected audience type.

```
STACK_NAME=ola-kbv-cri-common CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=3qstp8o17b IPV_CORE_STUB_BASIC_AUTH_USER=****** IPV_CORE_STUB_BASIC_AUTH_PASSWORD=********* IPV_CORE_STUB_URL="http://localhost:8085" DEFAULT_REDIRECT_URI="http://localhost:8085/callback"  gradle integration-tests:cucumber

```



- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks