### PR TITLE
Oj-1413: use middy in authorization handler

### DIFF
--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -18,7 +18,7 @@ import { logger, metrics, tracer as _tracer } from "../common/utils/power-tool";
 import { MetricUnits } from "@aws-lambda-powertools/metrics";
 import { injectLambdaContext } from "@aws-lambda-powertools/logger/lib/middleware/middy";
 import { RequestPayload } from "../types/request_payload";
-import getSessionById from "../middlewares/session/get-session-by-id";
+import getSessionByIdMiddleware from "../middlewares/session/get-session-by-id-middleware";
 import errorMiddleware from "../middlewares/error/error-middleware";
 import { ConfigService } from "../common/config/config-service";
 import { SSMClient } from "@aws-sdk/client-ssm";
@@ -108,5 +108,5 @@ export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
             ],
         }),
     )
-    .use(getSessionById({ sessionService: sessionService }))
+    .use(getSessionByIdMiddleware({ sessionService: sessionService }))
     .use(setGovUkSigningJourneyIdMiddleware(logger));

--- a/lambdas/src/middlewares/session/get-session-by-id-middleware.ts
+++ b/lambdas/src/middlewares/session/get-session-by-id-middleware.ts
@@ -1,21 +1,21 @@
 import { MiddlewareObj, Request } from "@middy/core";
 import { SessionService } from "../../services/session-service";
-import { RequestPayload } from "../../types/request_payload";
-import { SessionItem } from "../../types/session-item";
+import { getSessionId } from "../../common/utils/request-utils";
 
 const defaults = {};
 
-const getSessionById = (opts: { sessionService: SessionService }): MiddlewareObj => {
+const getSessionByIdMiddleware = (opts: { sessionService: SessionService }): MiddlewareObj => {
     const options = { ...defaults, ...opts };
 
     const before = async (request: Request) => {
-        const event_body = request.event.body as SessionItem & RequestPayload;
-        const sessionItem = await options.sessionService.getSession(event_body.sessionId);
+        const event = request.event;
+        const sessionId = event?.body?.sessionId || getSessionId(event);
+        const sessionItem = await options.sessionService.getSession(sessionId);
         request.event = {
             ...request.event,
             body: {
                 ...sessionItem,
-                ...event_body,
+                ...event.body,
             },
         };
         await request.event;
@@ -26,4 +26,4 @@ const getSessionById = (opts: { sessionService: SessionService }): MiddlewareObj
     };
 };
 
-export default getSessionById;
+export default getSessionByIdMiddleware;

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -18,7 +18,7 @@ import { InvalidRequestError, ServerError } from "../../../src/common/utils/erro
 import errorMiddleware from "../../../src/middlewares/error/error-middleware";
 import initialiseConfigMiddleware from "../../../src/middlewares/config/initialise-config-middleware";
 import getSessionByAuthCodeMiddleware from "../../../src/middlewares/session/get-session-by-auth-code-middleware";
-import getSessionById from "../../../src/middlewares/session/get-session-by-id";
+import getSessionByIdMiddleware from "../../../src/middlewares/session/get-session-by-id-middleware";
 import setGovUkSigningJourneyIdMiddleware from "../../../src/middlewares/session/set-gov-uk-signing-journey-id-middleware";
 import { CommonConfigKey } from "../../../src/types/config-keys";
 
@@ -97,7 +97,7 @@ describe("access-token-handler.ts", () => {
                 }),
             )
             .use(getSessionByAuthCodeMiddleware({ sessionService: sessionService }))
-            .use(getSessionById({ sessionService: sessionService }))
+            .use(getSessionByIdMiddleware({ sessionService: sessionService }))
             .use(setGovUkSigningJourneyIdMiddleware(logger));
     });
 


### PR DESCRIPTION
This is the 3rd PR that uses middy as a way to ensure that `govuk_signin_journey_id` sticks around, when using logger.appendkeys since middy is middleware, a series of middlewares are constructed to get the persisted id
see: https://github.com/alphagov/di-ipv-cri-common-lambdas/pull/190 for the 1st PR


### Why did it change

See https://govukverify.atlassian.net/browse/OJ-1413

### Issue tracking

- [OJ-1413](https://govukverify.atlassian.net/browse/OJ-1413)


[OJ-1413]: https://govukverify.atlassian.net/browse/OJ-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ