### PR TITLE
OJ-1435: Change audit date to seconds

### DIFF
--- a/lambdas/src/common/services/audit-service.ts
+++ b/lambdas/src/common/services/audit-service.ts
@@ -30,7 +30,7 @@ export class AuditService {
             event_name: `${this.auditConfig?.auditEventNamePrefix}_${eventType}`,
             extensions: context?.extensions ?? undefined,
             restricted: context?.personIdentity ?? undefined,
-            timestamp: Date.now(),
+            timestamp: Math.floor(Date.now() / 1000),
             user: auditEventUser,
         };
     }

--- a/lambdas/tests/unit/common/services/audit-service.test.ts
+++ b/lambdas/tests/unit/common/services/audit-service.test.ts
@@ -44,7 +44,7 @@ describe("AuditService", () => {
             };
         });
 
-        jest.spyOn(global.Date, "now").mockReturnValueOnce(1675382400);
+        jest.spyOn(global.Date, "now").mockReturnValueOnce(1681147957473);
 
         auditService = new AuditService(mockGetAuditConfig, mockSqsClient.prototype);
     });
@@ -69,7 +69,7 @@ describe("AuditService", () => {
                 event_name: `TEST_PREFIX_START`,
                 extensions: undefined,
                 restricted: undefined,
-                timestamp: 1675382400,
+                timestamp: 1681147957,
                 user: {
                     govuk_signin_journey_id: "test-client-session-id",
                     ip_address: undefined,
@@ -97,7 +97,7 @@ describe("AuditService", () => {
                 event_name: `TEST_PREFIX_START`,
                 extensions: undefined,
                 restricted: undefined,
-                timestamp: 1675382400,
+                timestamp: 1681147957,
                 user: {
                     govuk_signin_journey_id: undefined,
                     ip_address: undefined,


### PR DESCRIPTION
see: [OJ-1435](https://govukverify.atlassian.net/browse/OJ-1435)

This PR changes this to be in seconds.

## Proposed changes

### What changed

Audit timestamp changed to seconds

### Why did it change

The Audit date is currently in milliseconds this is throwing off the txma reports.

- [OJ-1435](https://govukverify.atlassian.net/browse/OJ-1435)


[OJ-1435]: https://govukverify.atlassian.net/browse/OJ-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-1435]: https://govukverify.atlassian.net/browse/OJ-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ