### PR TITLE
OJ-1439: Do logging in after hook of middleware

### DIFF
--- a/lambdas/src/middlewares/jwt/decrypt-jwe-middleware.ts
+++ b/lambdas/src/middlewares/jwt/decrypt-jwe-middleware.ts
@@ -1,6 +1,7 @@
 import { Logger } from "@aws-lambda-powertools/logger";
 import { MiddlewareObj, Request } from "@middy/core";
 import { JweDecrypter } from "../../services/security/jwe-decrypter";
+import { JWTPayload } from "jose/dist/types/types";
 
 const defaults = {};
 
@@ -17,11 +18,18 @@ const decryptJweMiddleware = (logger: Logger, opts: { jweDecrypter: JweDecrypter
                 clientId,
             },
         };
+        await request.event;
+    };
+    const after = async (request: Request) => {
+        const jwtPayload = request.event.body as unknown as JWTPayload;
+        const clientSessionId = jwtPayload["govuk_signin_journey_id"] as string;
+
+        logger.appendKeys({ govuk_signin_journey_id: clientSessionId });
         logger.info("JWE decrypted");
         await request.event;
     };
-
     return {
+        after,
         before,
     };
 };

--- a/lambdas/src/middlewares/jwt/validate-jwt-middleware.ts
+++ b/lambdas/src/middlewares/jwt/validate-jwt-middleware.ts
@@ -3,6 +3,7 @@ import { MiddlewareObj, Request } from "@middy/core";
 import { ConfigService } from "../../common/config/config-service";
 import { SessionRequestValidatorFactory } from "../../services/session-request-validator";
 import { JweRequest } from "../../types/jwe-request";
+import { JWTPayload } from "jose/dist/types/types";
 
 const defaults = {};
 
@@ -26,12 +27,20 @@ const validateJwtMiddleware = (
                 ...jwtPayload,
             },
         };
-        logger.info("JWT validated");
         await request.event;
     };
 
+    const after = async (request: Request) => {
+        const jwtPayload = request.event.body as unknown as JWTPayload;
+        const clientSessionId = jwtPayload["govuk_signin_journey_id"] as string;
+
+        logger.appendKeys({ govuk_signin_journey_id: clientSessionId });
+        logger.info("JWT validated");
+        await request.event;
+    };
     return {
         before,
+        after,
     };
 };
 


### PR DESCRIPTION
## Proposed changes

The gov uk signing journey id does not currently appear, this PR introduce after hooks in the session handler for where the above logging appears to be missing.

### What changed

Logging in the after hook of both the `decrypt-jwe-middleware.ts` and `validate-jwt-middleware.ts` ensures the journey signing id appears for when logging decryption of jwe and the validation jwt

### Why did it change

Improvements
