### PR TITLE
LIME-409 Switch dns mappings for di-ipv-cri-passport-api to review-pa

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -170,11 +170,11 @@ Mappings:
       integration: "https://review-d.integration.account.gov.uk"
       production: "https://review-d.account.gov.uk"
     di-ipv-cri-passport-api:
-      dev: "https://review-p.dev.account.gov.uk"
-      build: "https://review-p.build.account.gov.uk"
-      staging: "https://review-p.staging.account.gov.uk"
-      integration: "https://review-p.integration.account.gov.uk"
-      production: "https://review-p.account.gov.uk"
+      dev: "https://review-pa.dev.account.gov.uk"
+      build: "https://review-pa.build.account.gov.uk"
+      staging: "https://review-pa.staging.account.gov.uk"
+      integration: "https://review-pa.integration.account.gov.uk"
+      production: "https://review-pa.account.gov.uk"
 
   IPVCoreStubAwsBuildIssuerMapping:
     Environment:
@@ -290,11 +290,11 @@ Mappings:
       integration: "https://review-d.integration.account.gov.uk"
       production: "https://review-d.account.gov.uk"
     di-ipv-cri-passport-api:
-      dev: "https://review-p.dev.account.gov.uk"
-      build: "https://review-p.build.account.gov.uk"
-      staging: "https://review-p.staging.account.gov.uk"
-      integration: "https://review-p.integration.account.gov.uk"
-      production: "https://review-p.account.gov.uk"
+      dev: "https://review-pa.dev.account.gov.uk"
+      build: "https://review-pa.build.account.gov.uk"
+      staging: "https://review-pa.staging.account.gov.uk"
+      integration: "https://review-pa.integration.account.gov.uk"
+      production: "https://review-pa.account.gov.uk"
 
 Resources:
   SessionFunction:


### PR DESCRIPTION
## Proposed changes

### What changed

Switch dns mappings for di-ipv-cri-passport-api to review-pa from review-p

### Why did it change

review-pa dns is now live

### Issue tracking

- [LIME-409](https://govukverify.atlassian.net/browse/LIME-409)


[LIME-409]: https://govukverify.atlassian.net/browse/LIME-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ