### PR TITLE
OJ-1502: Made DEFAULT_CLIENT_ID into an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,20 @@ If you have not installed `pre-commit` then please do so [here](https://pre-comm
 
 ## Run Cucumber tests
 
+Below runs and uses the PAAS stub as default
+
 `STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" gradle integration-tests:cucumber
 `
+Below runs overriding default PAAS stub by using the AWS stub
+
+`
+STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk"  DEFAULT_REDIRECT_URI="https://cri.core.build.stubs.account.gov.uk/callback" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build gradle integration-tests:cucumber
+`
+
 You can run against local host as follows:
 
 Run the either KBV or ADDRESS front-end and ensure the you start the stub as well
 
 `STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" DEFAULT_REDIRECT_URI="http://localhost:8085/callback" gradle integration-tests:cucumber
+
 `

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -31,7 +31,8 @@ public class APISteps {
     private static final String DEFAULT_REDIRECT_URI =
             Optional.ofNullable(System.getenv("DEFAULT_REDIRECT_URI"))
                     .orElse("https://di-ipv-core-stub.london.cloudapps.digital/callback");
-    private static final String DEFAULT_CLIENT_ID = "ipv-core-stub";
+    private static final String DEFAULT_CLIENT_ID =
+            Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;


### PR DESCRIPTION
## Proposed changes

Allow running integration-test for common-lambda with the new AWS core stub

### What changed

Made DEFAULT_CLIENT_ID into an environment variable instead of being hard coded

### Why did it change

What to be able to run common-lambda integration test with new AWS core stub

### Issue tracking

- [OJ-1502](https://govukverify.atlassian.net/browse/OJ-1502)

## Checklists



[OJ-1502]: https://govukverify.atlassian.net/browse/OJ-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ