### PR TITLE
OJ-1540: Ensure integration test works with aws stubs

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -77,7 +77,8 @@ jobs:
 
       - name: Run API integration tests
         env:
-          IPV_CORE_STUB_URL: https://di-ipv-core-stub.london.cloudapps.digital
+          DEFAULT_CLIENT_ID: ipv-core-stub-aws-build
+          IPV_CORE_STUB_URL: https://cri.core.build.stubs.account.gov.uk
           IPV_CORE_STUB_BASIC_AUTH_USER: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
           IPV_CORE_STUB_BASIC_AUTH_PASSWORD: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}
         run: |

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ If you have not installed `pre-commit` then please do so [here](https://pre-comm
 Below runs and uses the PAAS stub as default
 
 `STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" gradle integration-tests:cucumber
-`
-Below runs overriding default PAAS stub by using the AWS stub
 
 `
-STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk"  DEFAULT_REDIRECT_URI="https://cri.core.build.stubs.account.gov.uk/callback" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build gradle integration-tests:cucumber
+Below runs overriding default PAAS stub by using the AWS stub
+`
+STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build gradle integration-tests:cucumber
 `
 
 You can run against local host as follows:
 
 Run the either KBV or ADDRESS front-end and ensure the you start the stub as well
 
-`STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" DEFAULT_REDIRECT_URI="http://localhost:8085/callback" gradle integration-tests:cucumber
+`STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" gradle integration-tests:cucumber
 
 `

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -13,7 +13,7 @@ import java.net.http.HttpResponse;
 import java.util.Objects;
 import java.util.Optional;
 
-import static gov.uk.di.ipv.cri.common.api.stepDefinitions.APISteps.DEV_ACCESS_TOKEN_URI;
+import static gov.uk.di.ipv.cri.common.api.stepDefinitions.APISteps.devAccessTokenUri;
 
 public class IpvCoreStubUtil {
 
@@ -117,12 +117,25 @@ public class IpvCoreStubUtil {
     }
 
     public static HttpResponse<String> sendAuthorizationRequest(
+            String apiPath, String sessionId, String clientId)
+            throws URISyntaxException, IOException, InterruptedException {
+        return sendAuthorizationRequest(apiPath, sessionId, null, clientId);
+    }
+
+    public static HttpResponse<String> sendAuthorizationRequest(
             String apiPath, String sessionId, String redirectUri, String clientId)
             throws URISyntaxException, IOException, InterruptedException {
         var url =
                 new URIBuilder(getPrivateApiEndpoint())
                         .setPath(apiPath)
-                        .addParameter("redirect_uri", redirectUri)
+                        .addParameter(
+                                "redirect_uri",
+                                Optional.ofNullable(redirectUri)
+                                        .orElse(
+                                                new URIBuilder(getIPVCoreStubURL())
+                                                        .setPath("/callback")
+                                                        .build()
+                                                        .toString()))
                         .addParameter("client_id", clientId)
                         .addParameter("response_type", "code")
                         .addParameter("scope", "openid")
@@ -158,12 +171,12 @@ public class IpvCoreStubUtil {
             throws URISyntaxException, IOException, InterruptedException {
 
         String privateKeyJWT = getPrivateKeyJWT(authorizationCode.trim());
-        System.out.println("DEV_ACCESS_TOKEN_URI is --------" + DEV_ACCESS_TOKEN_URI);
+        System.out.println("DEV_ACCESS_TOKEN_URI is --------" + devAccessTokenUri);
         var request =
                 HttpRequest.newBuilder()
                         .uri(
                                 new URIBuilder(getPrivateApiEndpoint())
-                                        .setPath(DEV_ACCESS_TOKEN_URI)
+                                        .setPath(devAccessTokenUri)
                                         .build())
                         .header("Content-Type", "application/x-www-form-urlencoded")
                         .POST(HttpRequest.BodyPublishers.ofString(privateKeyJWT))


### PR DESCRIPTION
## Proposed changes

Pre-merge-test to use AWS stub instead of PAAS stub

### What changed

Move away from PAAS to AWS hosting of stub

### Why did it change

PAAS would be decommission soon

### Issue tracking

- [OJ-1540](https://govukverify.atlassian.net/browse/OJ-1540)


### Environment variables or secrets

Use of DEFAULT_CLIENT_ID to specify stub client id

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1533]: https://govukverify.atlassian.net/browse/OJ-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OJ-1540]: https://govukverify.atlassian.net/browse/OJ-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ