### PR TITLE
BAU: Removed sysout calls to use a Logger and added fail fast of defa…

### DIFF
--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -15,28 +15,34 @@ import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import static gov.uk.di.ipv.cri.common.api.util.IpvCoreStubUtil.sendCreateAuthCodeRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class APISteps {
-
+    private static final Logger LOG = Logger.getLogger(APISteps.class.getName());
     private static final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
     private static String devSessionUri;
     private static String devAuthorizationUri;
     public static String devAccessTokenUri;
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final String DEFAULT_REDIRECT_URI =
-            Optional.ofNullable(System.getenv("IPV_CORE_STUB_URL") + "/callback")
-                    .orElse("https://di-ipv-core-stub.london.cloudapps.digital/callback");
     private static final String DEFAULT_CLIENT_ID =
             Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
+    private final String defaultRedirectUri;
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;
     private HttpResponse<String> response;
     private Map<String, String> responseBodyMap;
+
+    public APISteps() {
+        if(System.getenv().containsValue("IPV_CORE_STUB_URL")) {
+            defaultRedirectUri = String.format("%s/callback", System.getenv("IPV_CORE_STUB_URL"));
+        }
+        throw new RuntimeException("Missing environment variable: IPV_CORE_STUB_URL");
+    }
 
     @Given("authorization JAR for test user {int}")
     public void setAuthorizationJARForTestUser(int rowNumber)
@@ -63,7 +69,7 @@ public class APISteps {
     @When("user sends a request to session API")
     public void user_sends_a_request_to_session_api()
             throws URISyntaxException, IOException, InterruptedException {
-        System.out.println("DEV_SESSION_URI is --------" + devSessionUri);
+        LOG.info("DEV_SESSION_URI is --------" + devSessionUri);
         response = IpvCoreStubUtil.sendSessionRequest(devSessionUri, sessionRequestBody);
         responseBodyMap = objectMapper.readValue(response.body(), new TypeReference<>() {});
     }
@@ -98,7 +104,7 @@ public class APISteps {
     @When("user sends a valid request to authorization end point")
     public void user_sends_a_valid_request_to_authorization_end_point()
             throws IOException, InterruptedException, URISyntaxException {
-        System.out.println("DEV_AUTHORIZATION_URI is --------" + devAuthorizationUri);
+        LOG.info("DEV_AUTHORIZATION_URI is --------" + devAuthorizationUri);
         response =
                 IpvCoreStubUtil.sendAuthorizationRequest(
                         devAuthorizationUri, currentSessionId, DEFAULT_CLIENT_ID);
@@ -110,7 +116,7 @@ public class APISteps {
         currentAuthorizationCode = jsonNode.get("authorizationCode").get("value").textValue();
         assertEquals(
                 UUID.fromString(currentAuthorizationCode).toString(), currentAuthorizationCode);
-        assertEquals(DEFAULT_REDIRECT_URI, jsonNode.get("redirectionURI").textValue());
+        assertEquals(defaultRedirectUri, jsonNode.get("redirectionURI").textValue());
         assertEquals("state-ipv", jsonNode.get("state").get("value").textValue());
     }
 


### PR DESCRIPTION

## Proposed changes

### What changed
APISteps.java
<!-- Describe the changes in detail - the "what"-->

### Why did it change
It uses the default PaaS URL when there `IPV_CORE_STUB_URL` is missing. This will cause issues especially when PaaS gets decommissioned. Instead of a default value, the code will now fail-fast so it is immediate that the environment variable is missing. 

Additionally, the `System.out.println` calls have been replaced with the default Java logger as this gives us more more information and context when debugging. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks