### PR TITLE
oj-1516 toy deployments plus dev-platform upload action

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy.yml
+++ b/.github/workflows/post-merge-matrix-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, DL_DEV, PASSPORTA_DEV ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, DL_DEV, PASSPORTA_DEV, TOY_DEV ]
         include:
           - target: ADDRESS_DEV
             ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
@@ -30,11 +30,6 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: KBV_DEV_SIGNING_PROFILE_NAME
-          - target: KBV_POC
-            ENABLED: "${{ vars.KBV_POC_ENABLED }}"
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_COMMON_CRI_GH_ACTIONS_ROLE_ARN
-            SIGNING_PROFILE_NAME: KBV_POC_SIGNING_PROFILE_NAME
           - target: DL_DEV
             ENABLED: "${{ vars.DL_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
@@ -45,6 +40,11 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: PASSPORTA_DEV_SIGNING_PROFILE_NAME
+          - target: TOY_DEV
+            ENABLED: "${{ vars.TOY_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: TOY_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: TOY_DEV_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to dev
     runs-on: ubuntu-latest
@@ -95,35 +95,13 @@ jobs:
         if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
-      - name: Generate code signing config
+      - name: Deploy SAM application
         if: matrix.ENABLED == 'true'
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
+        uses: alphagov/di-devplatform-upload-action@v3.2
         with:
-          template: ./infrastructure/lambda/template.yaml
-          profile: ${{ secrets[matrix.SIGNING_PROFILE_NAME] }}
-
-      - name: SAM build
-        if: matrix.ENABLED == 'true'
-        run: sam build -t infrastructure/lambda/template.yaml
-
-      - name: SAM package
-        if: matrix.ENABLED == 'true'
-        run: |
-          sam package \
-            ${{ steps.signing.outputs.signing_config }} \
-            --s3-bucket ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }} \
-            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
-
-      - name: Zip the CloudFormation template
-        if: matrix.ENABLED == 'true'
-        run: zip template.zip cf-template.yaml
-
-      - name: Upload zipped CloudFormation artifact to S3
-        if: matrix.ENABLED == 'true'
-        env:
-          ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"
+            artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
+            signing-profile-name: "${{ secrets[matrix.SIGNING_PROFILE_NAME] }}"
+            working-directory: ./infrastructure/lambda
 
 
   publish_common_cri_to_matrix_build:
@@ -133,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, PASSPORTA_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, PASSPORTA_BUILD, TOY_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
@@ -160,6 +138,11 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    PASSPORTA_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME: PASSPORTA_BUILD_SIGNING_PROFILE_NAME
+          - target: TOY_BUILD
+            ENABLED: "${{ vars.TOY_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: TOY_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME: TOY_BUILD_SIGNING_PROFILE_NAME
       max-parallel: 2
     name: Publish common_cri infrastructure to build
     runs-on: ubuntu-latest
@@ -210,32 +193,11 @@ jobs:
         if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
-      - name: Generate code signing config
+      - name: Deploy SAM application
         if: matrix.ENABLED == 'true'
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
+        uses: alphagov/di-devplatform-upload-action@v3.2
         with:
-          template: ./infrastructure/lambda/template.yaml
-          profile: ${{ secrets[matrix.SIGNING_PROFILE_NAME] }}
+            artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
+            signing-profile-name: "${{ secrets[matrix.SIGNING_PROFILE_NAME] }}"
+            working-directory: ./infrastructure/lambda
 
-      - name: SAM build
-        if: matrix.ENABLED == 'true'
-        run: sam build -t infrastructure/lambda/template.yaml
-
-      - name: SAM package
-        if: matrix.ENABLED == 'true'
-        run: |
-          sam package \
-            ${{ steps.signing.outputs.signing_config }} \
-            --s3-bucket ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }} \
-            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
-
-      - name: Zip the CloudFormation template
-        if: matrix.ENABLED == 'true'
-        run: zip template.zip cf-template.yaml
-
-      - name: Upload zipped CloudFormation artifact to S3
-        if: matrix.ENABLED == 'true'
-        env:
-          ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -154,42 +154,42 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "2d38b09c23f1b328ae854888abfe0cf47b45c64a",
+        "hashed_secret": "99c84064f542ec25992874af52fae71443b6ed0e",
         "is_verified": false,
         "line_number": 35
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "d73fa283b0dc91b95f2ea1d555ebbdcbbfa43ab4",
+        "hashed_secret": "83ffd716b650129c64f17ee886bc87a817903cc9",
         "is_verified": false,
         "line_number": 36
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "99c84064f542ec25992874af52fae71443b6ed0e",
+        "hashed_secret": "128c5d07564551d58ada2b8863eccaedffddcc49",
         "is_verified": false,
         "line_number": 40
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "83ffd716b650129c64f17ee886bc87a817903cc9",
+        "hashed_secret": "6062421eba675dc39bd875b104c67871d6cc57c2",
         "is_verified": false,
         "line_number": 41
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "128c5d07564551d58ada2b8863eccaedffddcc49",
+        "hashed_secret": "b9357c5048ceb0268c4d049ad3fea619b449d4aa",
         "is_verified": false,
         "line_number": 45
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
-        "hashed_secret": "6062421eba675dc39bd875b104c67871d6cc57c2",
+        "hashed_secret": "dec2fb53a9513bba4293dea928ad231853feead2",
         "is_verified": false,
         "line_number": 46
       },
@@ -198,70 +198,84 @@
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "d9c4666052c745e7c6f573d794aca9a4a6f3be8e",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 118
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "b6fae911e0d430a113de3c48fc9cb2327bf8753b",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 119
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f981ab8fa303ef4573982a33a0871a35d65d7573",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 123
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "c30abc3ec374d49f5feecca6f4f3acfde26dda1d",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 124
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0dc638bfd1345bbff836dfd900fafe35f3f790c3",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "306aa35448086294107288ee1d8cda214081c212",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "0ec0ad1e2eb3fcd03bcd813c6ade3927eb58c621",
         "is_verified": false,
-        "line_number": 155
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "f5f97a4d43698c40eb4eb208e2df8cd688479904",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "2f9bddb21e782330751128eab5b0ee2bb32a8a5f",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy.yml",
         "hashed_secret": "9a8444839c9ddc2bde47db07accb97180f3ef522",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 139
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "bf19e43c703cad226a6e4612a76c626539c0c415",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy.yml",
+        "hashed_secret": "d0fa423647fc2a625d7d664cffbac8d7aa1c0f09",
+        "is_verified": false,
+        "line_number": 144
       }
     ],
     ".github/workflows/pre-merge-integration-test.yml": [
@@ -345,5 +359,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-25T12:49:37Z"
+  "generated_at": "2023-05-05T12:16:41Z"
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added the Toy CRI DEV and BUILD to the matrix and updated to use the dev-platform upload action 

### Why did it change

* The deployments are needed for the Toy CRI.
* The  Toy CRI has a full dev-platform stack which requires metadata for the hooks, the dev-platform upload action provides this metadata.

### Issue tracking

- [OJ-1516](https://govukverify.atlassian.net/browse/OJ-1516)

## Checklists

### Environment variables or secrets

- [ ] Documented in the [README](./blob/main/README.md)
- [X] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-1516]: https://govukverify.atlassian.net/browse/OJ-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ