### PR TITLE
BAU: Use logger instead of System.out.println and no Optional on ENV

### DIFF
--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -32,7 +32,7 @@ public class APISteps {
             (REDIRECT_URI.toLowerCase().startsWith("http"))
                     ? REDIRECT_URI + "/callback"
                     : "https://di-ipv-core-stub.london.cloudapps.digital/callback";
-    private static final String DEFAULT_CLIENT_ID = System.getenv("DEFAULT_CLIENT_ID");
+    private static final String DEFAULT_CLIENT_ID = "null";
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -32,7 +32,7 @@ public class APISteps {
             (REDIRECT_URI.toLowerCase().startsWith("http"))
                     ? REDIRECT_URI + "/callback"
                     : "https://di-ipv-core-stub.london.cloudapps.digital/callback";
-    private static final String DEFAULT_CLIENT_ID = "null";
+    private static final String DEFAULT_CLIENT_ID = System.getenv("DEFAULT_CLIENT_ID");
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -27,9 +27,12 @@ public class APISteps {
     private static String devAuthorizationUri;
     public static String devAccessTokenUri;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String REDIRECT_URI = System.getenv("IPV_CORE_STUB_URL");
     private static final String DEFAULT_REDIRECT_URI =
-            System.getenv("IPV_CORE_STUB_URL") + "/callback";
-    private static final String DEFAULT_CLIENT_ID = System.getenv("DEFAULT_CLIENT_ID");
+            (REDIRECT_URI.toLowerCase().startsWith("http"))
+                    ? REDIRECT_URI + "/callback"
+                    : "https://di-ipv-core-stub.london.cloudapps.digital/callback";
+    private static final String DEFAULT_CLIENT_ID = "null";
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -32,7 +33,8 @@ public class APISteps {
             (REDIRECT_URI.toLowerCase().startsWith("http"))
                     ? REDIRECT_URI + "/callback"
                     : "https://di-ipv-core-stub.london.cloudapps.digital/callback";
-    private static final String DEFAULT_CLIENT_ID = System.getenv("DEFAULT_CLIENT_ID");
+    private static final String DEFAULT_CLIENT_ID =
+            Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -13,25 +13,23 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import static gov.uk.di.ipv.cri.common.api.util.IpvCoreStubUtil.sendCreateAuthCodeRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class APISteps {
-
+    private static final Logger LOG = Logger.getLogger(APISteps.class.getName());
     private static final String ENVIRONMENT = "/dev"; // dev, build, staging, integration
     private static String devSessionUri;
     private static String devAuthorizationUri;
     public static String devAccessTokenUri;
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final String DEFAULT_REDIRECT_URI =
-            Optional.ofNullable(System.getenv("IPV_CORE_STUB_URL") + "/callback")
-                    .orElse("https://di-ipv-core-stub.london.cloudapps.digital/callback");
-    private static final String DEFAULT_CLIENT_ID =
-            Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
+            System.getenv("IPV_CORE_STUB_URL") + "/callback";
+    private static final String DEFAULT_CLIENT_ID = System.getenv("DEFAULT_CLIENT_ID");
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;
@@ -63,7 +61,7 @@ public class APISteps {
     @When("user sends a request to session API")
     public void user_sends_a_request_to_session_api()
             throws URISyntaxException, IOException, InterruptedException {
-        System.out.println("DEV_SESSION_URI is --------" + devSessionUri);
+        LOG.info("DEV_SESSION_URI is --------" + devSessionUri);
         response = IpvCoreStubUtil.sendSessionRequest(devSessionUri, sessionRequestBody);
         responseBodyMap = objectMapper.readValue(response.body(), new TypeReference<>() {});
     }
@@ -98,7 +96,7 @@ public class APISteps {
     @When("user sends a valid request to authorization end point")
     public void user_sends_a_valid_request_to_authorization_end_point()
             throws IOException, InterruptedException, URISyntaxException {
-        System.out.println("DEV_AUTHORIZATION_URI is --------" + devAuthorizationUri);
+        LOG.info("DEV_AUTHORIZATION_URI is --------" + devAuthorizationUri);
         response =
                 IpvCoreStubUtil.sendAuthorizationRequest(
                         devAuthorizationUri, currentSessionId, DEFAULT_CLIENT_ID);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
APISteps.java

<!-- Describe the changes in detail - the "what"-->

### Why did it change
* Use the Logger instead of `System.out.println` for better clarity of logs.
* Removed the use of `Optional.ofNullable` around the envs as `System.getenv()` will never be null so this call is redundant. Additionally, this removes the fallback of the PaaS URls which will eventually be decommissioned. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1540](https://govukverify.atlassian.net/browse/OJ-1540)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

[OJ-1540]: https://govukverify.atlassian.net/browse/OJ-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ