### PR TITLE
ci:update flow and add dev accounts

### DIFF
--- a/.github/workflows/post-merge-matrix-deploy-toy.yml
+++ b/.github/workflows/post-merge-matrix-deploy-toy.yml
@@ -64,14 +64,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ TOY_DEV ]
+        target: [ ADDRESS_DEV, DL_DEV, FRAUD_DEV, KBV_DEV, PASSPORTA_DEV, TOY_DEV ]
         include:
+          - target: ADDRESS_DEV
+            ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:         ADDRESS_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME:               ADDRESS_DEV_SIGNING_PROFILE_NAME
+          - target: DL_DEV
+            ENABLED: "${{ vars.DL_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:         DL_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME:               DL_DEV_SIGNING_PROFILE_NAME
+          - target: FRAUD_DEV
+            ENABLED: "${{ vars.FRAUD_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:         FRAUD_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME:               FRAUD_DEV_SIGNING_PROFILE_NAME
+          - target: KBV_DEV
+            ENABLED: "${{ vars.KBV_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:         KBV_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME:               KBV_DEV_SIGNING_PROFILE_NAME
+          - target: PASSPORTA_DEV
+            ENABLED: "${{ vars.PASSPORTA_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:         PASSPORTA_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
+            SIGNING_PROFILE_NAME:               PASSPORTA_DEV_SIGNING_PROFILE_NAME
           - target: TOY_DEV
             ENABLED: "${{ vars.TOY_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:         TOY_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME:               TOY_DEV_SIGNING_PROFILE_NAME
-      max-parallel: 2
+
+      # max-parallel: 2
     name: Sign and publish common_cri infrastructure to Dev
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -126,7 +152,7 @@ jobs:
           working-directory: ./out
 
   sign_and_publish_common_cri_to_build:
-    needs: build_common_cri
+    needs: sign_and_publish_common_cri_to_dev
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -138,7 +164,7 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:         TOY_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME:               TOY_BUILD_SIGNING_PROFILE_NAME
-      max-parallel: 2
+      # max-parallel: 2
     name: Sign and publish common_cri infrastructure to Build
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -112,30 +112,100 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
-        "hashed_secret": "b9357c5048ceb0268c4d049ad3fea619b449d4aa",
+        "hashed_secret": "9cfcc50fc0ad0be4e54b61eceb08f206528ef1c6",
         "is_verified": false,
         "line_number": 71
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
-        "hashed_secret": "dec2fb53a9513bba4293dea928ad231853feead2",
+        "hashed_secret": "14ed1673466790e3f01675618c018d4ef9083ca9",
         "is_verified": false,
         "line_number": 72
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "99c84064f542ec25992874af52fae71443b6ed0e",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "83ffd716b650129c64f17ee886bc87a817903cc9",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "903ffeaaff6ae224f320de93e49dc27666f877b9",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "84a189f3100c63f5fefb3ee3e661861a8d8ebf2d",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "2f2ae43baec845ea316514dea0279ecdce7b0362",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "fd4cb41e4ef40b21a7ef0320c30ca30dcf95206a",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "128c5d07564551d58ada2b8863eccaedffddcc49",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "6062421eba675dc39bd875b104c67871d6cc57c2",
+        "is_verified": false,
+        "line_number": 92
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "b9357c5048ceb0268c4d049ad3fea619b449d4aa",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
+        "hashed_secret": "dec2fb53a9513bba4293dea928ad231853feead2",
+        "is_verified": false,
+        "line_number": 97
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
         "hashed_secret": "bf19e43c703cad226a6e4612a76c626539c0c415",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 164
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-matrix-deploy-toy.yml",
         "hashed_secret": "d0fa423647fc2a625d7d664cffbac8d7aa1c0f09",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 165
       }
     ],
     ".github/workflows/post-merge-matrix-deploy.yml": [
@@ -375,5 +445,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-30T12:20:20Z"
+  "generated_at": "2023-05-30T15:58:58Z"
 }


### PR DESCRIPTION
## Proposed changes

### What changed

* Added additional dev accounts to dev matrix
* Updated matrices workflows to be sequential with build second
* Removed consecutive parallel publish restrictions

### Why did it change

* To better represent the overall design of the workflow
* Further improve performance

### Issue tracking

- [OJ-1581](https://govukverify.atlassian.net/browse/OJ-1581)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Existing workflow temporarily disabled from the GitHub console
Dev accounts and Toy build only

[OJ-1581]: https://govukverify.atlassian.net/browse/OJ-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ