### PR TITLE
LIME-619 Add CriVpcMapping for passport-v1 production

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -388,28 +392,28 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "407b058c0f67be53116117c4b021b5e95f9dca9e",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 229
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "486b0e17dde4271451ce7c815378fab9081085d1",
         "is_verified": false,
-        "line_number": 250
+        "line_number": 251
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "81249afd017322b40765e849988f74ebc18e757c",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 252
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "54ec3197768e4b02c47ff91d4858f80b0c6fad30",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 253
       }
     ],
     "session/src/test/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypterTest.java": [
@@ -445,5 +449,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-30T15:58:58Z"
+  "generated_at": "2023-06-01T13:52:36Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -143,6 +143,7 @@ Mappings:
       build: "di-devplatform-deploy"
       staging: "di-devplatform-deploy"
       integration: "di-devplatform-deploy"
+      production: "di-devplatform-deploy"
     di-ipv-cri-toy-api:
       dev: "di-devplatform-deploy"
       build: "di-devplatform-deploy"


### PR DESCRIPTION
## Proposed changes

### What changed

Add CriVpcMapping for passport-v1 production

### Why did it change

To allow common-api to deploy into passport-v1 production

### Issue tracking

- [LIME-619](https://govukverify.atlassian.net/browse/LIME-619)

## Checklists


[LIME-619]: https://govukverify.atlassian.net/browse/LIME-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ