### PR TITLE
Switch di-ipv-cri-passport-api to use di-devplatform-deploy values in dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -139,7 +139,7 @@ Mappings:
       integration: "di-ipv-cri-pipeline-deployment"
       production: "di-ipv-cri-pipeline-deployment"
     di-ipv-cri-passport-api:
-      dev: "di-ipv-cri-pipeline-deployment" # cri-dev
+      dev: "di-devplatform-deploy"
       build: "di-devplatform-deploy"
       staging: "di-devplatform-deploy"
       integration: "di-devplatform-deploy"


### PR DESCRIPTION
## Proposed changes

### What changed

Switch di-ipv-cri-passport-api to use di-devplatform-deploy values in dev environment

### Why did it change

To allow common-api to deploy via pipline into passport-v1-dev

### Issue tracking

- [LIME-619](https://govukverify.atlassian.net/browse/LIME-619)

[LIME-619]: https://govukverify.atlassian.net/browse/LIME-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ