### PR TITLE
OJ-1663 Create audit event queue consumer lambda

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -302,28 +302,28 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "407b058c0f67be53116117c4b021b5e95f9dca9e",
         "is_verified": false,
-        "line_number": 229
+        "line_number": 231
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "486b0e17dde4271451ce7c815378fab9081085d1",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 253
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "81249afd017322b40765e849988f74ebc18e757c",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "54ec3197768e4b02c47ff91d4858f80b0c6fad30",
         "is_verified": false,
-        "line_number": 253
+        "line_number": 255
       }
     ],
     "session/src/test/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypterTest.java": [
@@ -359,5 +359,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-23T10:54:31Z"
+  "generated_at": "2023-06-29T14:43:21Z"
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,12 +17,12 @@ fi
 
 if [ -z "$audit_event_name_prefix" ]
 then
-  audit_event_name_prefix="/common-cri-parameters/AuditEventNamePrefix"
+  audit_event_name_prefix="/common-cri-parameters/KbvAuditEventNamePrefix"
 fi
 
 if [ -z "$cri_identifier" ]
 then
-  cri_identifier="/common-cri-parameters/CriIdentifier"
+  cri_identifier="/common-cri-parameters/KbvCriIdentifier"
 fi
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,12 +17,12 @@ fi
 
 if [ -z "$audit_event_name_prefix" ]
 then
-  audit_event_name_prefix="/common-cri-parameters/KbvAuditEventNamePrefix"
+  audit_event_name_prefix="/common-cri-parameters/AuditEventNamePrefix"
 fi
 
 if [ -z "$cri_identifier" ]
 then
-  cri_identifier="/common-cri-parameters/KbvCriIdentifier"
+  cri_identifier="/common-cri-parameters/CriIdentifier"
 fi
 
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -351,6 +351,54 @@ Resources:
   # Stub Audit Event Consumer  #
   ##############################
 
+  AuditEventQueueConsumerRole:
+    Type: AWS::IAM::Role
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      Description: >
+        A role to use in the SQS queue and KMS key policies. To be overridden in envs other than dev and build with
+        supplied TXMA roles when they exist.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: AWSLambdaBasicExecutionRole
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: ReadSqs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "sqs:SendMessage"
+                  - "sqs:ReceiveMessage"
+                  - "sqs:DeleteMessage"
+                  - "sqs:GetQueueAttributes"
+                Resource:
+                  - !Sub
+                    - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
+                    - queueName: !ImportValue AuditEventQueueName
+              - Effect: Allow
+                Action:
+                  - 'kms:Decrypt'
+                  - 'kms:GenerateDataKey'
+                Resource:
+                  - !ImportValue AuditEventQueueEncryptionKeyArn
+
   AuditEventConsumerFunction:
     Type: AWS::Serverless::Function
     Condition: IsNotProdLikeEnvironment
@@ -362,19 +410,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-audit-event-consumer"
-      Policies:
-        - AWSLambdaBasicExecutionRole
-        - AWSXrayWriteOnlyAccess
-        - Statement:
-            - Effect: Allow
-              Action:
-                - sqs:ReceiveMessage
-                - sqs:DeleteMessage
-                - sqs:GetQueueAttributes
-              Resource:
-                - !Sub
-                  - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
-                  - queueName: !ImportValue AuditEventQueueName
+      Role: !GetAtt AuditEventQueueConsumerRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -383,30 +383,24 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
-        - PolicyName: ReadSqs
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "sqs:SendMessage"
-                  - "sqs:ReceiveMessage"
-                  - "sqs:DeleteMessage"
-                  - "sqs:GetQueueAttributes"
-                Resource:
-                  - !Sub
-                    - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
-                    - queueName: !ImportValue AuditEventQueueName
-        - PolicyName: DecryptMessages
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - 'kms:Decrypt'
-                  - 'kms:GenerateDataKey'
-                Resource:
-                  - !ImportValue AuditEventQueueEncryptionKeyArn
+        - Statement:
+          - Effect: Allow
+            Action:
+              - "sqs:SendMessage"
+              - "sqs:ReceiveMessage"
+              - "sqs:DeleteMessage"
+              - "sqs:GetQueueAttributes"
+            Resource:
+              - !Sub
+                - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
+                - queueName: !ImportValue AuditEventQueueName
+        - Statement:
+          - Effect: Allow
+            Action:
+              - 'kms:Decrypt'
+              - 'kms:GenerateDataKey'
+            Resource:
+              - !ImportValue AuditEventQueueEncryptionKeyArn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1215,6 +1215,14 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${AuditEventConsumerFunction}"
       RetentionInDays: 30
 
+  AuditEventConsumerFunctionEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 10
+      Enabled: true
+      EventSourceArn: !GetAtt StubAuditEventQueue.Arn
+      FunctionName: !GetAtt AuditEventConsumerFunction.Arn
+
 Outputs:
   StackName:
     Description: "CloudFormation stack name"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -46,6 +46,8 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsNotProdLikeEnvironment: !Not 
+    - Condition: IsProdLikeEnvironment
   IsProdEnvironment: !Equals
     - !Ref Environment
     - production
@@ -344,6 +346,68 @@ Mappings:
       production: "https://review-toy.account.gov.uk"
 
 Resources:
+
+  ##############################
+  # Stub Audit Event Consumer  #
+  ##############################
+
+  AuditEventConsumerFunction:
+    Type: AWS::Serverless::Function
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      Handler: audit-event-consumer-handler.lambdaHandler
+      CodeUri: ../../lambdas
+      Runtime: nodejs18.x
+      FunctionName: !Sub "${AWS::StackName}-AuditEventConsumerFunction"
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-audit-event-consumer"
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - Statement:
+            - Effect: Allow
+              Action:
+                - sqs:ReceiveMessage
+                - sqs:DeleteMessage
+                - sqs:GetQueueAttributes
+              Resource:
+                - !Sub
+                  - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
+                  - queueName: !ImportValue AuditEventQueueName
+    Metadata: # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "node18"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/audit-event-consumer-handler.ts
+        External:
+          - '@aws-sdk/*'
+
+  AuditEventConsumerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AuditEventConsumerFunction}"
+      RetentionInDays: 30
+
+  AuditEventConsumerFunctionEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      BatchSize: 10
+      Enabled: true
+      EventSourceArn: !Sub
+        - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
+        - queueName: !ImportValue AuditEventQueueName
+      FunctionName: !Ref AuditEventConsumerFunction
+
+  #########################
+  # Common OAuth Lambdas  #
+  #########################
+
   SessionFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -1163,65 +1227,6 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PreMergeDevOnlyApi}-private-AccessLogs
       RetentionInDays: 7
-
-  StubAuditEventQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      MessageRetentionPeriod: 604800 # 7 days
-      VisibilityTimeout: 360
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt StubAuditEventDLQ.Arn
-        maxReceiveCount: 1
-
-  StubAuditEventDLQ:
-    Type: AWS::SQS::Queue
-    Properties:
-      MessageRetentionPeriod: 604800 # 7 days
-      VisibilityTimeout: 360
-
-  AuditEventConsumerFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: audit-event-consumer-lambda.lambdaHandler
-      CodeUri: ../../lambdas
-      Runtime: nodejs18.x
-      FunctionName: !Sub "${AWS::StackName}-AuditEventConsumerFunction"
-      Environment:
-        Variables:
-          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-audit-event-consumer"
-      Policies:
-        - AWSLambdaBasicExecutionRole
-        - AWSXrayWriteOnlyAccess
-        - Statement:
-            - Effect: Allow
-              Action:
-                - sqs:ReceiveMessage
-              Resource:
-                - !GetAtt StubAuditEventQueue.Arn
-    Metadata: # Manage esbuild properties
-      BuildMethod: esbuild
-      BuildProperties:
-        Minify: true
-        Target: "node18"
-        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
-        EntryPoints:
-          - src/handlers/audit-event-consumer-handler.ts
-        External:
-          - '@aws-sdk/*'
-
-  AuditEventConsumerFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambda/${AuditEventConsumerFunction}"
-      RetentionInDays: 30
-
-  AuditEventConsumerFunctionEventSourceMapping:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      BatchSize: 10
-      Enabled: true
-      EventSourceArn: !GetAtt StubAuditEventQueue.Arn
-      FunctionName: !GetAtt AuditEventConsumerFunction.Arn
 
 Outputs:
   StackName:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -368,16 +368,8 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: AWSLambdaBasicExecutionRole
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "logs:CreateLogGroup"
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
-                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
         - PolicyName: ReadSqs
           PolicyDocument:
             Version: "2012-10-17"
@@ -392,6 +384,10 @@ Resources:
                   - !Sub
                     - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
                     - queueName: !ImportValue AuditEventQueueName
+        - PolicyName: DecryptMessages
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
               - Effect: Allow
                 Action:
                   - 'kms:Decrypt'

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1164,6 +1164,57 @@ Resources:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PreMergeDevOnlyApi}-private-AccessLogs
       RetentionInDays: 7
 
+  StubAuditEventQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 604800 # 7 days
+      VisibilityTimeout: 360
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt StubAuditEventDLQ.Arn
+        maxReceiveCount: 1
+
+  StubAuditEventDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 604800 # 7 days
+      VisibilityTimeout: 360
+
+  AuditEventConsumerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: audit-event-consumer-lambda.lambdaHandler
+      CodeUri: ../../lambdas
+      Runtime: nodejs18.x
+      FunctionName: !Sub "${AWS::StackName}-AuditEventConsumerFunction"
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-audit-event-consumer"
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - Statement:
+            - Effect: Allow
+              Action:
+                - sqs:ReceiveMessage
+              Resource:
+                - !GetAtt StubAuditEventQueue.Arn
+    Metadata: # Manage esbuild properties
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "node18"
+        Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
+        EntryPoints:
+          - src/handlers/audit-event-consumer-handler.ts
+        External:
+          - '@aws-sdk/*'
+
+  AuditEventConsumerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AuditEventConsumerFunction}"
+      RetentionInDays: 30
+
 Outputs:
   StackName:
     Description: "CloudFormation stack name"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -351,22 +351,35 @@ Resources:
   # Stub Audit Event Consumer  #
   ##############################
 
-  AuditEventQueueConsumerRole:
-    Type: AWS::IAM::Role
+  # AuditEventQueueConsumerRole:
+  #   Type: AWS::IAM::Role
+  #   Condition: IsNotProdLikeEnvironment
+  #   Properties:
+  #     Description: >
+  #       A role to use in the SQS queue and KMS key policies. To be overridden in envs other than dev and build with
+  #       supplied TXMA roles when they exist.
+  #     AssumeRolePolicyDocument:
+  #       Version: "2012-10-17"
+  #       Statement:
+  #         - Effect: Allow
+  #           Principal:
+  #             Service:
+  #               - lambda.amazonaws.com
+  #           Action:
+  #             - 'sts:AssumeRole'
+  #     Policies:
+
+  AuditEventConsumerFunction:
+    Type: AWS::Serverless::Function
     Condition: IsNotProdLikeEnvironment
     Properties:
-      Description: >
-        A role to use in the SQS queue and KMS key policies. To be overridden in envs other than dev and build with
-        supplied TXMA roles when they exist.
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - 'sts:AssumeRole'
+      Handler: audit-event-consumer-handler.lambdaHandler
+      CodeUri: ../../lambdas
+      Runtime: nodejs18.x
+      FunctionName: !Sub "${AWS::StackName}-AuditEventConsumerFunction"
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-audit-event-consumer"
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -394,19 +407,6 @@ Resources:
                   - 'kms:GenerateDataKey'
                 Resource:
                   - !ImportValue AuditEventQueueEncryptionKeyArn
-
-  AuditEventConsumerFunction:
-    Type: AWS::Serverless::Function
-    Condition: IsNotProdLikeEnvironment
-    Properties:
-      Handler: audit-event-consumer-handler.lambdaHandler
-      CodeUri: ../../lambdas
-      Runtime: nodejs18.x
-      FunctionName: !Sub "${AWS::StackName}-AuditEventConsumerFunction"
-      Environment:
-        Variables:
-          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-audit-event-consumer"
-      Role: !GetAtt AuditEventQueueConsumerRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -351,24 +351,6 @@ Resources:
   # Stub Audit Event Consumer  #
   ##############################
 
-  # AuditEventQueueConsumerRole:
-  #   Type: AWS::IAM::Role
-  #   Condition: IsNotProdLikeEnvironment
-  #   Properties:
-  #     Description: >
-  #       A role to use in the SQS queue and KMS key policies. To be overridden in envs other than dev and build with
-  #       supplied TXMA roles when they exist.
-  #     AssumeRolePolicyDocument:
-  #       Version: "2012-10-17"
-  #       Statement:
-  #         - Effect: Allow
-  #           Principal:
-  #             Service:
-  #               - lambda.amazonaws.com
-  #           Action:
-  #             - 'sts:AssumeRole'
-  #     Policies:
-
   AuditEventConsumerFunction:
     Type: AWS::Serverless::Function
     Condition: IsNotProdLikeEnvironment

--- a/lambdas/.eslintignore
+++ b/lambdas/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 .aws-sam
+build

--- a/lambdas/src/handlers/audit-event-consumer-handler.ts
+++ b/lambdas/src/handlers/audit-event-consumer-handler.ts
@@ -1,0 +1,25 @@
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import middy from "@middy/core";
+import { SQSEvent } from "aws-lambda";
+import { logger, metrics, tracer as _tracer } from "../common/utils/power-tool";
+import errorMiddleware from "../middlewares/error/error-middleware";
+
+const AUDIT_EVENT_CONSUMED = "audit_event_consumed";
+
+export class AuditEventConsumerLambda implements LambdaInterface {
+    @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
+    @_tracer.captureLambdaHandler({ captureResponse: false })
+    public async handler(event: SQSEvent, _context: unknown): Promise<void> {
+        for (const record of event.Records) {
+            logger.info("Audit event consumed:", JSON.parse(record.body));
+        }
+    }
+}
+
+const handlerClass = new AuditEventConsumerLambda();
+export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass)).use(
+    errorMiddleware(logger, metrics, {
+        metric_name: AUDIT_EVENT_CONSUMED,
+        message: "Audit Event Consumer Lambda error occurred",
+    }),
+);

--- a/lambdas/src/handlers/audit-event-consumer-handler.ts
+++ b/lambdas/src/handlers/audit-event-consumer-handler.ts
@@ -11,7 +11,8 @@ export class AuditEventConsumerLambda implements LambdaInterface {
     @_tracer.captureLambdaHandler({ captureResponse: false })
     public async handler(event: SQSEvent, _context: unknown): Promise<void> {
         for (const record of event.Records) {
-            logger.info("Audit event consumed", JSON.parse(record.body));
+            const body = JSON.parse(record.body);
+            logger.info("Audit event consumed", body.event_name, `Session ID: ${body.user.session_id}`);
         }
     }
 }

--- a/lambdas/src/handlers/audit-event-consumer-handler.ts
+++ b/lambdas/src/handlers/audit-event-consumer-handler.ts
@@ -11,7 +11,7 @@ export class AuditEventConsumerLambda implements LambdaInterface {
     @_tracer.captureLambdaHandler({ captureResponse: false })
     public async handler(event: SQSEvent, _context: unknown): Promise<void> {
         for (const record of event.Records) {
-            logger.info("Audit event consumed:", JSON.parse(record.body));
+            logger.info("Audit event consumed", JSON.parse(record.body));
         }
     }
 }

--- a/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
+++ b/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
@@ -56,7 +56,7 @@ describe("audit-event-consumer-handler.ts", () => {
         expect(loggerSpy).toHaveBeenCalledWith(
             "Audit event consumed",
             "IPV_KBV_CRI_RESPONSE_RECEIVED",
-            "Session ID: 6492fead-283b-4fa9-b57a-6f7da8f3fbb8"
+            "Session ID: 6492fead-283b-4fa9-b57a-6f7da8f3fbb8",
         );
     });
 });

--- a/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
+++ b/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
@@ -1,0 +1,58 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { Metrics } from "@aws-lambda-powertools/metrics";
+import middy from "@middy/core";
+import { Context, SQSEvent, SQSRecord } from "aws-lambda";
+import { AuditEventConsumerLambda } from "../../../src/handlers/audit-event-consumer-handler";
+import errorMiddleware from "../../../src/middlewares/error/error-middleware";
+
+describe("access-token-handler.ts", () => {
+    const logger = jest.mocked(Logger);
+    const metrics = jest.mocked(Metrics);
+    let auditEventConsumerLambda: AuditEventConsumerLambda;
+
+    let lambdaHandler: middy.MiddyfiedHandler;
+
+    beforeEach(() => {
+        auditEventConsumerLambda = new AuditEventConsumerLambda();
+        lambdaHandler = middy(auditEventConsumerLambda.handler.bind(auditEventConsumerLambda)).use(
+            errorMiddleware(logger.prototype, metrics.prototype, {
+                metric_name: "audit_event_consumed",
+                message: "Audit Event Consumer Lambda error occurred",
+            }),
+        );
+    });
+
+    it("should log all SQS messages in the event", async () => {
+        const loggerSpy = jest.spyOn(logger.prototype, "info");
+        const mockBody = {
+            timestamp: 1687446254,
+            event_name: "IPV_KBV_CRI_RESPONSE_RECEIVED",
+            component_id: "https://review-k.build.account.gov.uk",
+            user: {
+                user_id: "urn:fdc:gov.uk:2022:12b83ddf-79ff-454c-a3fd-67a9f8963cdd",
+                ip_address: "172.177.150.115, 10.1.60.204",
+                session_id: "6492fead-283b-4fa9-b57a-6f7da8f3fbb8",
+                persistent_session_id: "87bbeda2-1bd7-4e3b-8d0a-66a2adcf6908",
+                govuk_signin_journey_id: "a381c877-5cb4-4579-bf96-661ec5744224",
+            },
+            extensions: { experianIiqResponse: { outcome: null } },
+        };
+        const mockEvent: SQSEvent = {
+            Records: [
+                {
+                    messageId: "messageId",
+                    receiptHandle: "receiptHandle",
+                    body: JSON.stringify(mockBody),
+                    messageAttributes: {},
+                    md5OfBody: "string",
+                    eventSource: "string",
+                    eventSourceARN: "string",
+                    awsRegion: "string",
+                } as SQSRecord,
+            ],
+        };
+        await lambdaHandler(mockEvent, {} as Context);
+        expect(loggerSpy).toHaveBeenCalledTimes(1);
+        expect(loggerSpy).toHaveBeenCalledWith("Audit event consumed:", mockBody);
+    });
+});

--- a/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
+++ b/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
@@ -5,7 +5,7 @@ import { Context, SQSEvent, SQSRecord } from "aws-lambda";
 import { AuditEventConsumerLambda } from "../../../src/handlers/audit-event-consumer-handler";
 import errorMiddleware from "../../../src/middlewares/error/error-middleware";
 
-describe("access-token-handler.ts", () => {
+describe("audit-event-consumer-handler.ts", () => {
     const logger = jest.mocked(Logger);
     const metrics = jest.mocked(Metrics);
     let auditEventConsumerLambda: AuditEventConsumerLambda;

--- a/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
+++ b/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
@@ -53,6 +53,10 @@ describe("audit-event-consumer-handler.ts", () => {
         };
         await lambdaHandler(mockEvent, {} as Context);
         expect(loggerSpy).toHaveBeenCalledTimes(1);
-        expect(loggerSpy).toHaveBeenCalledWith("Audit event consumed", mockBody);
+        expect(loggerSpy).toHaveBeenCalledWith(
+            "Audit event consumed",
+            "IPV_KBV_CRI_RESPONSE_RECEIVED",
+            "Session ID: 6492fead-283b-4fa9-b57a-6f7da8f3fbb8"
+        );
     });
 });

--- a/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
+++ b/lambdas/tests/unit/handlers/audit-event-consumer.test.ts
@@ -53,6 +53,6 @@ describe("audit-event-consumer-handler.ts", () => {
         };
         await lambdaHandler(mockEvent, {} as Context);
         expect(loggerSpy).toHaveBeenCalledTimes(1);
-        expect(loggerSpy).toHaveBeenCalledWith("Audit event consumed:", mockBody);
+        expect(loggerSpy).toHaveBeenCalledWith("Audit event consumed", mockBody);
     });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Creation of a lambda to consume the audit events off the queue

### Why did it change

To prevent txma being overwhelmed by the number of messages that performance testing will generate

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1663](https://govukverify.atlassian.net/browse/OJ-1663)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[OJ-1663]: https://govukverify.atlassian.net/browse/OJ-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ