### PR TITLE
LIME-802: Updating common lambdas for passport api so the issuer remains review-p

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -366,11 +366,11 @@ Mappings:
       integration: "https://review-d.integration.account.gov.uk"
       production: "https://review-d.account.gov.uk"
     di-ipv-cri-passport-api:
-      dev: "https://review-pa.dev.account.gov.uk"
-      build: "https://review-pa.build.account.gov.uk"
-      staging: "https://review-pa.staging.account.gov.uk"
-      integration: "https://review-pa.integration.account.gov.uk"
-      production: "https://review-pa.account.gov.uk"
+      dev: "https://review-p.dev.account.gov.uk"
+      build: "https://review-p.build.account.gov.uk"
+      staging: "https://review-p.staging.account.gov.uk"
+      integration: "https://review-p.integration.account.gov.uk"
+      production: "https://review-p.account.gov.uk"
     di-ipv-cri-toy-api:
       dev: "https://review-toy.dev.account.gov.uk"
       build: "https://review-toy.build.account.gov.uk"


### PR DESCRIPTION
## Proposed changes

Updating the common lambdas so review-p is used as the VC issuer rather than review-pa

### What changed

Updated the template to set the issuer for passport-api to review-p

### Why did it change

So that when the new passport cri goes live the VCs issued are the same as the values expected by core and spot

