### PR TITLE
oj-1931 add mappings for HMRC API's

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -339,6 +339,14 @@ Mappings:
       production: "https://identity.account.gov.uk/credential-issuer/callback?id=ukPassport"
     di-ipv-cri-toy-api:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=toy"
+    di-ipv-cri-check-hmrc-api:
+      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=checkHmrc"
+      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=checkHmrc"
+      production: "https://identity.account.gov.uk/credential-issuer/callback?id=checkHmrc"
+    di-ipv-cri-kbv-hmrc-api:
+      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbvHmrc"
+      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=kbvHmrc"
+      production: "https://identity.account.gov.uk/credential-issuer/callback?id=kbvHmrc"
 
   VerifiableCredentialIssuerMapping:
     di-ipv-cri-address-api:


### PR DESCRIPTION
## Proposed changes

### What changed

Added redirect mappings for HMRC Check and KBV

### Why did it change

Redirect mappings are required for staging thru prod

### Issue tracking

- [OJ-1931](https://govukverify.atlassian.net/browse/OJ-1931)
- [OJ-1951](https://govukverify.atlassian.net/browse/OJ-1951)
- [IPS-306](https://govukverify.atlassian.net/browse/IPS-306)
- 
## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed


[OJ-1931]: https://govukverify.atlassian.net/browse/OJ-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-1951]: https://govukverify.atlassian.net/browse/OJ-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-306]: https://govukverify.atlassian.net/browse/IPS-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ